### PR TITLE
Remove limit on numeric value of OS handles from Files.Mod

### DIFF
--- a/bootstrap/unix-44/Configuration.c
+++ b/bootstrap/unix-44/Configuration.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 
 
@@ -13,6 +13,6 @@ export void *Configuration__init(void)
 	__DEFMOD;
 	__REGMOD("Configuration", 0);
 /* BEGIN */
-	__MOVE("1.95 [2016/07/19] for gcc LP64 on cygwin", Configuration_versionLong, 41);
+	__MOVE("1.95 [2016/07/21] for gcc LP64 on cygwin", Configuration_versionLong, 41);
 	__ENDMOD;
 }

--- a/bootstrap/unix-44/Configuration.h
+++ b/bootstrap/unix-44/Configuration.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Configuration__h
 #define Configuration__h

--- a/bootstrap/unix-44/Console.c
+++ b/bootstrap/unix-44/Console.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Platform.h"
 

--- a/bootstrap/unix-44/Console.h
+++ b/bootstrap/unix-44/Console.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Console__h
 #define Console__h

--- a/bootstrap/unix-44/Files.c
+++ b/bootstrap/unix-44/Files.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 #include "SYSTEM.h"
 #include "Configuration.h"
 #include "Console.h"
@@ -7,7 +7,7 @@
 #include "Strings.h"
 
 typedef
-	struct Files_Handle *Files_File;
+	struct Files_FileDesc *Files_File;
 
 typedef
 	struct Files_BufDesc {
@@ -24,14 +24,15 @@ typedef
 	CHAR Files_FileName[101];
 
 typedef
-	struct Files_Handle {
+	struct Files_FileDesc {
 		Files_FileName workName, registerName;
 		BOOLEAN tempFile;
 		Platform_FileIdentity identity;
 		LONGINT fd, len, pos;
 		Files_Buffer bufs[4];
 		INTEGER swapper, state;
-	} Files_Handle;
+		Files_File next;
+	} Files_FileDesc;
 
 typedef
 	struct Files_Rider {
@@ -42,7 +43,7 @@ typedef
 	} Files_Rider;
 
 
-static LONGINT Files_fileTab[256];
+static Files_File Files_files;
 static INTEGER Files_tempno;
 static CHAR Files_HOME[1024];
 static struct {
@@ -50,7 +51,7 @@ static struct {
 	CHAR data[1];
 } *Files_SearchPath;
 
-export LONGINT *Files_Handle__typ;
+export LONGINT *Files_FileDesc__typ;
 export LONGINT *Files_BufDesc__typ;
 export LONGINT *Files_Rider__typ;
 
@@ -58,6 +59,7 @@ export Files_File Files_Base (Files_Rider *r, LONGINT *r__typ);
 static Files_File Files_CacheEntry (Platform_FileIdentity identity);
 export void Files_ChangeDirectory (CHAR *path, LONGINT path__len, INTEGER *res);
 export void Files_Close (Files_File f);
+static void Files_CloseOSFile (Files_File f);
 static void Files_Create (Files_File f);
 export void Files_Delete (CHAR *name, LONGINT name__len, INTEGER *res);
 static void Files_Err (CHAR *s, LONGINT s__len, Files_File f, INTEGER errcode);
@@ -68,7 +70,6 @@ export void Files_GetDate (Files_File f, LONGINT *t, LONGINT *d);
 export void Files_GetName (Files_File f, CHAR *name, LONGINT name__len);
 static void Files_GetTempName (CHAR *finalName, LONGINT finalName__len, CHAR *name, LONGINT name__len);
 static BOOLEAN Files_HasDir (CHAR *name, LONGINT name__len);
-static void Files_Init (void);
 export LONGINT Files_Length (Files_File f);
 static void Files_MakeFileName (CHAR *dir, LONGINT dir__len, CHAR *name, LONGINT name__len, CHAR *dest, LONGINT dest__len);
 export Files_File Files_New (CHAR *name, LONGINT name__len);
@@ -225,26 +226,14 @@ static void Files_Create (Files_File f)
 		error = Platform_Unlink((void*)f->workName, ((LONGINT)(101)));
 		error = Platform_New((void*)f->workName, ((LONGINT)(101)), &f->fd);
 		done = error == 0;
-		if ((!done && Platform_TooManyFiles(error)) || (done && f->fd >= 256)) {
-			if ((done && f->fd >= 256)) {
-				error = Platform_Close(f->fd);
-			}
-			Heap_GC(1);
-			error = Platform_New((void*)f->workName, ((LONGINT)(101)), &f->fd);
-			done = f->fd == 0;
-		}
 		if (done) {
-			if (f->fd >= 256) {
-				error = Platform_Close(f->fd);
-				Files_Err((CHAR*)"too many files open", (LONGINT)20, f, 0);
-			} else {
-				Files_fileTab[f->fd] = (LONGINT)(uintptr_t)f;
-				Heap_FileCount += 1;
-				Heap_RegisterFinalizer((void*)f, Files_Finalize);
-				f->state = 0;
-				f->pos = 0;
-				error = Platform_Identify(f->fd, &f->identity, Platform_FileIdentity__typ);
-			}
+			f->next = Files_files;
+			Files_files = f;
+			Heap_FileCount += 1;
+			Heap_RegisterFinalizer((void*)f, Files_Finalize);
+			f->state = 0;
+			f->pos = 0;
+			error = Platform_Identify(f->fd, &f->identity, Platform_FileIdentity__typ);
 		} else {
 			if (Platform_NoSuchDirectory(error)) {
 				__MOVE("no such directory", err, 18);
@@ -281,6 +270,27 @@ static void Files_Flush (Files_Buffer buf)
 	}
 }
 
+static void Files_CloseOSFile (Files_File f)
+{
+	Files_File prev = NIL;
+	INTEGER error;
+	if (Files_files == f) {
+		Files_files = f->next;
+	} else {
+		prev = Files_files;
+		while ((prev != NIL && prev->next != f)) {
+			prev = prev->next;
+		}
+		if (prev->next != NIL) {
+			prev->next = f->next;
+		}
+	}
+	error = Platform_Close(f->fd);
+	f->fd = -1;
+	f->state = 1;
+	Heap_FileCount -= 1;
+}
+
 void Files_Close (Files_File f)
 {
 	LONGINT i;
@@ -296,11 +306,7 @@ void Files_Close (Files_File f)
 		if (error != 0) {
 			Files_Err((CHAR*)"error writing file", (LONGINT)19, f, error);
 		}
-		Files_fileTab[f->fd] = 0;
-		error = Platform_Close(f->fd);
-		f->fd = -1;
-		f->state = 1;
-		Heap_FileCount -= 1;
+		Files_CloseOSFile(f);
 	}
 }
 
@@ -316,7 +322,7 @@ Files_File Files_New (CHAR *name, LONGINT name__len)
 	Files_File _o_result;
 	Files_File f = NIL;
 	__DUP(name, name__len, CHAR);
-	__NEW(f, Files_Handle);
+	__NEW(f, Files_FileDesc);
 	f->workName[0] = 0x00;
 	__COPY(name, f->registerName, ((LONGINT)(101)));
 	f->fd = -1;
@@ -392,10 +398,9 @@ static Files_File Files_CacheEntry (Platform_FileIdentity identity)
 	Files_File _o_result;
 	Files_File f = NIL;
 	INTEGER i, error;
-	i = 0;
-	while (i < 256) {
-		f = (Files_File)(uintptr_t)Files_fileTab[i];
-		if ((f != NIL && Platform_SameFile(identity, f->identity))) {
+	f = Files_files;
+	while (f != NIL) {
+		if (Platform_SameFile(identity, f->identity)) {
 			if (!Platform_SameFileTime(identity, f->identity)) {
 				i = 0;
 				while (i < 4) {
@@ -412,7 +417,7 @@ static Files_File Files_CacheEntry (Platform_FileIdentity identity)
 			_o_result = f;
 			return _o_result;
 		}
-		i += 1;
+		f = f->next;
 	}
 	_o_result = NIL;
 	return _o_result;
@@ -442,16 +447,8 @@ Files_File Files_Old (CHAR *name, LONGINT name__len)
 		for (;;) {
 			error = Platform_OldRW((void*)path, ((LONGINT)(256)), &fd);
 			done = error == 0;
-			if ((!done && Platform_TooManyFiles(error)) || (done && fd >= 256)) {
-				if ((done && fd >= 256)) {
-					error = Platform_Close(fd);
-				}
-				Heap_GC(1);
-				error = Platform_OldRW((void*)path, ((LONGINT)(256)), &fd);
-				done = error == 0;
-				if ((!done && Platform_TooManyFiles(error))) {
-					Files_Err((CHAR*)"too many files open", (LONGINT)20, f, error);
-				}
+			if ((!done && Platform_TooManyFiles(error))) {
+				Files_Err((CHAR*)"too many files open", (LONGINT)20, f, error);
 			}
 			if ((!done && Platform_Inaccessible(error))) {
 				error = Platform_OldRO((void*)path, ((LONGINT)(256)), &fd);
@@ -468,17 +465,11 @@ Files_File Files_Old (CHAR *name, LONGINT name__len)
 				error = Platform_Identify(fd, &identity, Platform_FileIdentity__typ);
 				f = Files_CacheEntry(identity);
 				if (f != NIL) {
-					error = Platform_Close(fd);
 					_o_result = f;
 					__DEL(name);
 					return _o_result;
-				} else if (fd >= 256) {
-					error = Platform_Close(fd);
-					Files_Err((CHAR*)"too many files open", (LONGINT)20, f, 0);
 				} else {
-					__NEW(f, Files_Handle);
-					Files_fileTab[fd] = (LONGINT)(uintptr_t)f;
-					Heap_FileCount += 1;
+					__NEW(f, Files_FileDesc);
 					Heap_RegisterFinalizer((void*)f, Files_Finalize);
 					f->fd = fd;
 					f->state = 0;
@@ -489,6 +480,9 @@ Files_File Files_Old (CHAR *name, LONGINT name__len)
 					f->registerName[0] = 0x00;
 					f->tempFile = 0;
 					f->identity = identity;
+					f->next = Files_files;
+					Files_files = f;
+					Heap_FileCount += 1;
 					_o_result = f;
 					__DEL(name);
 					return _o_result;
@@ -1014,10 +1008,7 @@ static void Files_Finalize (SYSTEM_PTR o)
 	LONGINT res;
 	f = (Files_File)(uintptr_t)o;
 	if (f->fd >= 0) {
-		Files_fileTab[f->fd] = 0;
-		res = Platform_Close(f->fd);
-		f->fd = -1;
-		Heap_FileCount -= 1;
+		Files_CloseOSFile(f);
 		if (f->tempFile) {
 			res = Platform_Unlink((void*)f->workName, ((LONGINT)(101)));
 		}
@@ -1036,27 +1027,13 @@ void Files_SetSearchPath (CHAR *path, LONGINT path__len)
 	__DEL(path);
 }
 
-static void Files_Init (void)
-{
-	LONGINT i;
-	i = 0;
-	while (i < 256) {
-		Files_fileTab[i] = 0;
-		i += 1;
-	}
-	Files_tempno = -1;
-	Heap_FileCount = 0;
-	Files_SearchPath = NIL;
-	Files_HOME[0] = 0x00;
-	Platform_GetEnv((CHAR*)"HOME", (LONGINT)5, (void*)Files_HOME, ((LONGINT)(1024)));
-}
-
 static void EnumPtrs(void (*P)(void*))
 {
+	P(Files_files);
 	P(Files_SearchPath);
 }
 
-__TDESC(Files_Handle, 1, 4) = {__TDFLDS("Handle", 248), {228, 232, 236, 240, -20}};
+__TDESC(Files_FileDesc, 1, 5) = {__TDFLDS("FileDesc", 252), {228, 232, 236, 240, 248, -24}};
 __TDESC(Files_BufDesc, 1, 1) = {__TDFLDS("BufDesc", 4112), {0, -8}};
 __TDESC(Files_Rider, 1, 1) = {__TDFLDS("Rider", 20), {8, -8}};
 
@@ -1069,10 +1046,13 @@ export void *Files__init(void)
 	__MODULE_IMPORT(Platform);
 	__MODULE_IMPORT(Strings);
 	__REGMOD("Files", EnumPtrs);
-	__INITYP(Files_Handle, Files_Handle, 0);
+	__INITYP(Files_FileDesc, Files_FileDesc, 0);
 	__INITYP(Files_BufDesc, Files_BufDesc, 0);
 	__INITYP(Files_Rider, Files_Rider, 0);
 /* BEGIN */
-	Files_Init();
+	Files_tempno = -1;
+	Heap_FileCount = 0;
+	Files_HOME[0] = 0x00;
+	Platform_GetEnv((CHAR*)"HOME", (LONGINT)5, (void*)Files_HOME, ((LONGINT)(1024)));
 	__ENDMOD;
 }

--- a/bootstrap/unix-44/Files.h
+++ b/bootstrap/unix-44/Files.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 
 #ifndef Files__h
 #define Files__h
@@ -6,14 +6,14 @@
 #include "SYSTEM.h"
 
 typedef
-	struct Files_Handle *Files_File;
+	struct Files_FileDesc *Files_File;
 
 typedef
-	struct Files_Handle {
+	struct Files_FileDesc {
 		char _prvt0[216];
 		LONGINT fd;
-		char _prvt1[28];
-	} Files_Handle;
+		char _prvt1[32];
+	} Files_FileDesc;
 
 typedef
 	struct Files_Rider {
@@ -24,7 +24,7 @@ typedef
 
 
 
-import LONGINT *Files_Handle__typ;
+import LONGINT *Files_FileDesc__typ;
 import LONGINT *Files_Rider__typ;
 
 import Files_File Files_Base (Files_Rider *r, LONGINT *r__typ);

--- a/bootstrap/unix-44/Heap.c
+++ b/bootstrap/unix-44/Heap.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tskSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tskSfF */
 #include "SYSTEM.h"
 
 struct Heap__1 {

--- a/bootstrap/unix-44/Heap.h
+++ b/bootstrap/unix-44/Heap.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tskSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tskSfF */
 
 #ifndef Heap__h
 #define Heap__h

--- a/bootstrap/unix-44/Modules.c
+++ b/bootstrap/unix-44/Modules.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Console.h"
 #include "Heap.h"

--- a/bootstrap/unix-44/Modules.h
+++ b/bootstrap/unix-44/Modules.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Modules__h
 #define Modules__h

--- a/bootstrap/unix-44/OPB.c
+++ b/bootstrap/unix-44/OPB.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "OPM.h"
 #include "OPS.h"

--- a/bootstrap/unix-44/OPB.h
+++ b/bootstrap/unix-44/OPB.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPB__h
 #define OPB__h

--- a/bootstrap/unix-44/OPC.c
+++ b/bootstrap/unix-44/OPC.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Configuration.h"
 #include "OPM.h"

--- a/bootstrap/unix-44/OPC.h
+++ b/bootstrap/unix-44/OPC.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPC__h
 #define OPC__h

--- a/bootstrap/unix-44/OPM.c
+++ b/bootstrap/unix-44/OPM.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Configuration.h"
 #include "Console.h"

--- a/bootstrap/unix-44/OPM.h
+++ b/bootstrap/unix-44/OPM.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPM__h
 #define OPM__h

--- a/bootstrap/unix-44/OPP.c
+++ b/bootstrap/unix-44/OPP.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "OPB.h"
 #include "OPM.h"

--- a/bootstrap/unix-44/OPP.h
+++ b/bootstrap/unix-44/OPP.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPP__h
 #define OPP__h

--- a/bootstrap/unix-44/OPS.c
+++ b/bootstrap/unix-44/OPS.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 #include "SYSTEM.h"
 #include "OPM.h"
 

--- a/bootstrap/unix-44/OPS.h
+++ b/bootstrap/unix-44/OPS.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 
 #ifndef OPS__h
 #define OPS__h

--- a/bootstrap/unix-44/OPT.c
+++ b/bootstrap/unix-44/OPT.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "OPM.h"
 #include "OPS.h"

--- a/bootstrap/unix-44/OPT.h
+++ b/bootstrap/unix-44/OPT.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPT__h
 #define OPT__h

--- a/bootstrap/unix-44/OPV.c
+++ b/bootstrap/unix-44/OPV.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "OPC.h"
 #include "OPM.h"

--- a/bootstrap/unix-44/OPV.h
+++ b/bootstrap/unix-44/OPV.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPV__h
 #define OPV__h

--- a/bootstrap/unix-44/Platform.c
+++ b/bootstrap/unix-44/Platform.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 
 typedef

--- a/bootstrap/unix-44/Platform.h
+++ b/bootstrap/unix-44/Platform.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Platform__h
 #define Platform__h

--- a/bootstrap/unix-44/Reals.c
+++ b/bootstrap/unix-44/Reals.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 
 

--- a/bootstrap/unix-44/Reals.h
+++ b/bootstrap/unix-44/Reals.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Reals__h
 #define Reals__h

--- a/bootstrap/unix-44/Strings.c
+++ b/bootstrap/unix-44/Strings.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 
 

--- a/bootstrap/unix-44/Strings.h
+++ b/bootstrap/unix-44/Strings.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Strings__h
 #define Strings__h

--- a/bootstrap/unix-44/Texts.c
+++ b/bootstrap/unix-44/Texts.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Files.h"
 #include "Modules.h"

--- a/bootstrap/unix-44/Texts.h
+++ b/bootstrap/unix-44/Texts.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Texts__h
 #define Texts__h

--- a/bootstrap/unix-44/Vishap.c
+++ b/bootstrap/unix-44/Vishap.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkamSf */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkamSf */
 #include "SYSTEM.h"
 #include "Configuration.h"
 #include "Heap.h"

--- a/bootstrap/unix-44/errors.c
+++ b/bootstrap/unix-44/errors.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 
 typedef

--- a/bootstrap/unix-44/errors.h
+++ b/bootstrap/unix-44/errors.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef errors__h
 #define errors__h

--- a/bootstrap/unix-44/extTools.c
+++ b/bootstrap/unix-44/extTools.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Configuration.h"
 #include "Console.h"

--- a/bootstrap/unix-44/extTools.h
+++ b/bootstrap/unix-44/extTools.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef extTools__h
 #define extTools__h

--- a/bootstrap/unix-44/vt100.c
+++ b/bootstrap/unix-44/vt100.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Console.h"
 #include "Strings.h"

--- a/bootstrap/unix-44/vt100.h
+++ b/bootstrap/unix-44/vt100.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef vt100__h
 #define vt100__h

--- a/bootstrap/unix-48/Configuration.c
+++ b/bootstrap/unix-48/Configuration.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 
 
@@ -13,6 +13,6 @@ export void *Configuration__init(void)
 	__DEFMOD;
 	__REGMOD("Configuration", 0);
 /* BEGIN */
-	__MOVE("1.95 [2016/07/19] for gcc LP64 on cygwin", Configuration_versionLong, 41);
+	__MOVE("1.95 [2016/07/21] for gcc LP64 on cygwin", Configuration_versionLong, 41);
 	__ENDMOD;
 }

--- a/bootstrap/unix-48/Configuration.h
+++ b/bootstrap/unix-48/Configuration.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Configuration__h
 #define Configuration__h

--- a/bootstrap/unix-48/Console.c
+++ b/bootstrap/unix-48/Console.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Platform.h"
 

--- a/bootstrap/unix-48/Console.h
+++ b/bootstrap/unix-48/Console.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Console__h
 #define Console__h

--- a/bootstrap/unix-48/Files.c
+++ b/bootstrap/unix-48/Files.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 #include "SYSTEM.h"
 #include "Configuration.h"
 #include "Console.h"
@@ -7,7 +7,7 @@
 #include "Strings.h"
 
 typedef
-	struct Files_Handle *Files_File;
+	struct Files_FileDesc *Files_File;
 
 typedef
 	struct Files_BufDesc {
@@ -24,14 +24,15 @@ typedef
 	CHAR Files_FileName[101];
 
 typedef
-	struct Files_Handle {
+	struct Files_FileDesc {
 		Files_FileName workName, registerName;
 		BOOLEAN tempFile;
 		Platform_FileIdentity identity;
 		LONGINT fd, len, pos;
 		Files_Buffer bufs[4];
 		INTEGER swapper, state;
-	} Files_Handle;
+		Files_File next;
+	} Files_FileDesc;
 
 typedef
 	struct Files_Rider {
@@ -42,7 +43,7 @@ typedef
 	} Files_Rider;
 
 
-static LONGINT Files_fileTab[256];
+static Files_File Files_files;
 static INTEGER Files_tempno;
 static CHAR Files_HOME[1024];
 static struct {
@@ -50,7 +51,7 @@ static struct {
 	CHAR data[1];
 } *Files_SearchPath;
 
-export LONGINT *Files_Handle__typ;
+export LONGINT *Files_FileDesc__typ;
 export LONGINT *Files_BufDesc__typ;
 export LONGINT *Files_Rider__typ;
 
@@ -58,6 +59,7 @@ export Files_File Files_Base (Files_Rider *r, LONGINT *r__typ);
 static Files_File Files_CacheEntry (Platform_FileIdentity identity);
 export void Files_ChangeDirectory (CHAR *path, LONGINT path__len, INTEGER *res);
 export void Files_Close (Files_File f);
+static void Files_CloseOSFile (Files_File f);
 static void Files_Create (Files_File f);
 export void Files_Delete (CHAR *name, LONGINT name__len, INTEGER *res);
 static void Files_Err (CHAR *s, LONGINT s__len, Files_File f, INTEGER errcode);
@@ -68,7 +70,6 @@ export void Files_GetDate (Files_File f, LONGINT *t, LONGINT *d);
 export void Files_GetName (Files_File f, CHAR *name, LONGINT name__len);
 static void Files_GetTempName (CHAR *finalName, LONGINT finalName__len, CHAR *name, LONGINT name__len);
 static BOOLEAN Files_HasDir (CHAR *name, LONGINT name__len);
-static void Files_Init (void);
 export LONGINT Files_Length (Files_File f);
 static void Files_MakeFileName (CHAR *dir, LONGINT dir__len, CHAR *name, LONGINT name__len, CHAR *dest, LONGINT dest__len);
 export Files_File Files_New (CHAR *name, LONGINT name__len);
@@ -225,26 +226,14 @@ static void Files_Create (Files_File f)
 		error = Platform_Unlink((void*)f->workName, ((LONGINT)(101)));
 		error = Platform_New((void*)f->workName, ((LONGINT)(101)), &f->fd);
 		done = error == 0;
-		if ((!done && Platform_TooManyFiles(error)) || (done && f->fd >= 256)) {
-			if ((done && f->fd >= 256)) {
-				error = Platform_Close(f->fd);
-			}
-			Heap_GC(1);
-			error = Platform_New((void*)f->workName, ((LONGINT)(101)), &f->fd);
-			done = f->fd == 0;
-		}
 		if (done) {
-			if (f->fd >= 256) {
-				error = Platform_Close(f->fd);
-				Files_Err((CHAR*)"too many files open", (LONGINT)20, f, 0);
-			} else {
-				Files_fileTab[f->fd] = (LONGINT)(uintptr_t)f;
-				Heap_FileCount += 1;
-				Heap_RegisterFinalizer((void*)f, Files_Finalize);
-				f->state = 0;
-				f->pos = 0;
-				error = Platform_Identify(f->fd, &f->identity, Platform_FileIdentity__typ);
-			}
+			f->next = Files_files;
+			Files_files = f;
+			Heap_FileCount += 1;
+			Heap_RegisterFinalizer((void*)f, Files_Finalize);
+			f->state = 0;
+			f->pos = 0;
+			error = Platform_Identify(f->fd, &f->identity, Platform_FileIdentity__typ);
 		} else {
 			if (Platform_NoSuchDirectory(error)) {
 				__MOVE("no such directory", err, 18);
@@ -281,6 +270,27 @@ static void Files_Flush (Files_Buffer buf)
 	}
 }
 
+static void Files_CloseOSFile (Files_File f)
+{
+	Files_File prev = NIL;
+	INTEGER error;
+	if (Files_files == f) {
+		Files_files = f->next;
+	} else {
+		prev = Files_files;
+		while ((prev != NIL && prev->next != f)) {
+			prev = prev->next;
+		}
+		if (prev->next != NIL) {
+			prev->next = f->next;
+		}
+	}
+	error = Platform_Close(f->fd);
+	f->fd = -1;
+	f->state = 1;
+	Heap_FileCount -= 1;
+}
+
 void Files_Close (Files_File f)
 {
 	LONGINT i;
@@ -296,11 +306,7 @@ void Files_Close (Files_File f)
 		if (error != 0) {
 			Files_Err((CHAR*)"error writing file", (LONGINT)19, f, error);
 		}
-		Files_fileTab[f->fd] = 0;
-		error = Platform_Close(f->fd);
-		f->fd = -1;
-		f->state = 1;
-		Heap_FileCount -= 1;
+		Files_CloseOSFile(f);
 	}
 }
 
@@ -316,7 +322,7 @@ Files_File Files_New (CHAR *name, LONGINT name__len)
 	Files_File _o_result;
 	Files_File f = NIL;
 	__DUP(name, name__len, CHAR);
-	__NEW(f, Files_Handle);
+	__NEW(f, Files_FileDesc);
 	f->workName[0] = 0x00;
 	__COPY(name, f->registerName, ((LONGINT)(101)));
 	f->fd = -1;
@@ -392,10 +398,9 @@ static Files_File Files_CacheEntry (Platform_FileIdentity identity)
 	Files_File _o_result;
 	Files_File f = NIL;
 	INTEGER i, error;
-	i = 0;
-	while (i < 256) {
-		f = (Files_File)(uintptr_t)Files_fileTab[i];
-		if ((f != NIL && Platform_SameFile(identity, f->identity))) {
+	f = Files_files;
+	while (f != NIL) {
+		if (Platform_SameFile(identity, f->identity)) {
 			if (!Platform_SameFileTime(identity, f->identity)) {
 				i = 0;
 				while (i < 4) {
@@ -412,7 +417,7 @@ static Files_File Files_CacheEntry (Platform_FileIdentity identity)
 			_o_result = f;
 			return _o_result;
 		}
-		i += 1;
+		f = f->next;
 	}
 	_o_result = NIL;
 	return _o_result;
@@ -442,16 +447,8 @@ Files_File Files_Old (CHAR *name, LONGINT name__len)
 		for (;;) {
 			error = Platform_OldRW((void*)path, ((LONGINT)(256)), &fd);
 			done = error == 0;
-			if ((!done && Platform_TooManyFiles(error)) || (done && fd >= 256)) {
-				if ((done && fd >= 256)) {
-					error = Platform_Close(fd);
-				}
-				Heap_GC(1);
-				error = Platform_OldRW((void*)path, ((LONGINT)(256)), &fd);
-				done = error == 0;
-				if ((!done && Platform_TooManyFiles(error))) {
-					Files_Err((CHAR*)"too many files open", (LONGINT)20, f, error);
-				}
+			if ((!done && Platform_TooManyFiles(error))) {
+				Files_Err((CHAR*)"too many files open", (LONGINT)20, f, error);
 			}
 			if ((!done && Platform_Inaccessible(error))) {
 				error = Platform_OldRO((void*)path, ((LONGINT)(256)), &fd);
@@ -468,17 +465,11 @@ Files_File Files_Old (CHAR *name, LONGINT name__len)
 				error = Platform_Identify(fd, &identity, Platform_FileIdentity__typ);
 				f = Files_CacheEntry(identity);
 				if (f != NIL) {
-					error = Platform_Close(fd);
 					_o_result = f;
 					__DEL(name);
 					return _o_result;
-				} else if (fd >= 256) {
-					error = Platform_Close(fd);
-					Files_Err((CHAR*)"too many files open", (LONGINT)20, f, 0);
 				} else {
-					__NEW(f, Files_Handle);
-					Files_fileTab[fd] = (LONGINT)(uintptr_t)f;
-					Heap_FileCount += 1;
+					__NEW(f, Files_FileDesc);
 					Heap_RegisterFinalizer((void*)f, Files_Finalize);
 					f->fd = fd;
 					f->state = 0;
@@ -489,6 +480,9 @@ Files_File Files_Old (CHAR *name, LONGINT name__len)
 					f->registerName[0] = 0x00;
 					f->tempFile = 0;
 					f->identity = identity;
+					f->next = Files_files;
+					Files_files = f;
+					Heap_FileCount += 1;
 					_o_result = f;
 					__DEL(name);
 					return _o_result;
@@ -1014,10 +1008,7 @@ static void Files_Finalize (SYSTEM_PTR o)
 	LONGINT res;
 	f = (Files_File)(uintptr_t)o;
 	if (f->fd >= 0) {
-		Files_fileTab[f->fd] = 0;
-		res = Platform_Close(f->fd);
-		f->fd = -1;
-		Heap_FileCount -= 1;
+		Files_CloseOSFile(f);
 		if (f->tempFile) {
 			res = Platform_Unlink((void*)f->workName, ((LONGINT)(101)));
 		}
@@ -1036,27 +1027,13 @@ void Files_SetSearchPath (CHAR *path, LONGINT path__len)
 	__DEL(path);
 }
 
-static void Files_Init (void)
-{
-	LONGINT i;
-	i = 0;
-	while (i < 256) {
-		Files_fileTab[i] = 0;
-		i += 1;
-	}
-	Files_tempno = -1;
-	Heap_FileCount = 0;
-	Files_SearchPath = NIL;
-	Files_HOME[0] = 0x00;
-	Platform_GetEnv((CHAR*)"HOME", (LONGINT)5, (void*)Files_HOME, ((LONGINT)(1024)));
-}
-
 static void EnumPtrs(void (*P)(void*))
 {
+	P(Files_files);
 	P(Files_SearchPath);
 }
 
-__TDESC(Files_Handle, 1, 4) = {__TDFLDS("Handle", 248), {228, 232, 236, 240, -20}};
+__TDESC(Files_FileDesc, 1, 5) = {__TDFLDS("FileDesc", 252), {228, 232, 236, 240, 248, -24}};
 __TDESC(Files_BufDesc, 1, 1) = {__TDFLDS("BufDesc", 4112), {0, -8}};
 __TDESC(Files_Rider, 1, 1) = {__TDFLDS("Rider", 20), {8, -8}};
 
@@ -1069,10 +1046,13 @@ export void *Files__init(void)
 	__MODULE_IMPORT(Platform);
 	__MODULE_IMPORT(Strings);
 	__REGMOD("Files", EnumPtrs);
-	__INITYP(Files_Handle, Files_Handle, 0);
+	__INITYP(Files_FileDesc, Files_FileDesc, 0);
 	__INITYP(Files_BufDesc, Files_BufDesc, 0);
 	__INITYP(Files_Rider, Files_Rider, 0);
 /* BEGIN */
-	Files_Init();
+	Files_tempno = -1;
+	Heap_FileCount = 0;
+	Files_HOME[0] = 0x00;
+	Platform_GetEnv((CHAR*)"HOME", (LONGINT)5, (void*)Files_HOME, ((LONGINT)(1024)));
 	__ENDMOD;
 }

--- a/bootstrap/unix-48/Files.h
+++ b/bootstrap/unix-48/Files.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 
 #ifndef Files__h
 #define Files__h
@@ -6,14 +6,14 @@
 #include "SYSTEM.h"
 
 typedef
-	struct Files_Handle *Files_File;
+	struct Files_FileDesc *Files_File;
 
 typedef
-	struct Files_Handle {
+	struct Files_FileDesc {
 		char _prvt0[216];
 		LONGINT fd;
-		char _prvt1[28];
-	} Files_Handle;
+		char _prvt1[32];
+	} Files_FileDesc;
 
 typedef
 	struct Files_Rider {
@@ -24,7 +24,7 @@ typedef
 
 
 
-import LONGINT *Files_Handle__typ;
+import LONGINT *Files_FileDesc__typ;
 import LONGINT *Files_Rider__typ;
 
 import Files_File Files_Base (Files_Rider *r, LONGINT *r__typ);

--- a/bootstrap/unix-48/Heap.c
+++ b/bootstrap/unix-48/Heap.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tskSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tskSfF */
 #include "SYSTEM.h"
 
 struct Heap__1 {

--- a/bootstrap/unix-48/Heap.h
+++ b/bootstrap/unix-48/Heap.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tskSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tskSfF */
 
 #ifndef Heap__h
 #define Heap__h

--- a/bootstrap/unix-48/Modules.c
+++ b/bootstrap/unix-48/Modules.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Console.h"
 #include "Heap.h"

--- a/bootstrap/unix-48/Modules.h
+++ b/bootstrap/unix-48/Modules.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Modules__h
 #define Modules__h

--- a/bootstrap/unix-48/OPB.c
+++ b/bootstrap/unix-48/OPB.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "OPM.h"
 #include "OPS.h"

--- a/bootstrap/unix-48/OPB.h
+++ b/bootstrap/unix-48/OPB.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPB__h
 #define OPB__h

--- a/bootstrap/unix-48/OPC.c
+++ b/bootstrap/unix-48/OPC.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Configuration.h"
 #include "OPM.h"

--- a/bootstrap/unix-48/OPC.h
+++ b/bootstrap/unix-48/OPC.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPC__h
 #define OPC__h

--- a/bootstrap/unix-48/OPM.c
+++ b/bootstrap/unix-48/OPM.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Configuration.h"
 #include "Console.h"

--- a/bootstrap/unix-48/OPM.h
+++ b/bootstrap/unix-48/OPM.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPM__h
 #define OPM__h

--- a/bootstrap/unix-48/OPP.c
+++ b/bootstrap/unix-48/OPP.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "OPB.h"
 #include "OPM.h"

--- a/bootstrap/unix-48/OPP.h
+++ b/bootstrap/unix-48/OPP.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPP__h
 #define OPP__h

--- a/bootstrap/unix-48/OPS.c
+++ b/bootstrap/unix-48/OPS.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 #include "SYSTEM.h"
 #include "OPM.h"
 

--- a/bootstrap/unix-48/OPS.h
+++ b/bootstrap/unix-48/OPS.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 
 #ifndef OPS__h
 #define OPS__h

--- a/bootstrap/unix-48/OPT.c
+++ b/bootstrap/unix-48/OPT.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "OPM.h"
 #include "OPS.h"

--- a/bootstrap/unix-48/OPT.h
+++ b/bootstrap/unix-48/OPT.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPT__h
 #define OPT__h

--- a/bootstrap/unix-48/OPV.c
+++ b/bootstrap/unix-48/OPV.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "OPC.h"
 #include "OPM.h"

--- a/bootstrap/unix-48/OPV.h
+++ b/bootstrap/unix-48/OPV.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPV__h
 #define OPV__h

--- a/bootstrap/unix-48/Platform.c
+++ b/bootstrap/unix-48/Platform.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 
 typedef

--- a/bootstrap/unix-48/Platform.h
+++ b/bootstrap/unix-48/Platform.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Platform__h
 #define Platform__h

--- a/bootstrap/unix-48/Reals.c
+++ b/bootstrap/unix-48/Reals.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 
 

--- a/bootstrap/unix-48/Reals.h
+++ b/bootstrap/unix-48/Reals.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Reals__h
 #define Reals__h

--- a/bootstrap/unix-48/Strings.c
+++ b/bootstrap/unix-48/Strings.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 
 

--- a/bootstrap/unix-48/Strings.h
+++ b/bootstrap/unix-48/Strings.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Strings__h
 #define Strings__h

--- a/bootstrap/unix-48/Texts.c
+++ b/bootstrap/unix-48/Texts.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Files.h"
 #include "Modules.h"

--- a/bootstrap/unix-48/Texts.h
+++ b/bootstrap/unix-48/Texts.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Texts__h
 #define Texts__h

--- a/bootstrap/unix-48/Vishap.c
+++ b/bootstrap/unix-48/Vishap.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkamSf */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkamSf */
 #include "SYSTEM.h"
 #include "Configuration.h"
 #include "Heap.h"

--- a/bootstrap/unix-48/errors.c
+++ b/bootstrap/unix-48/errors.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 
 typedef

--- a/bootstrap/unix-48/errors.h
+++ b/bootstrap/unix-48/errors.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef errors__h
 #define errors__h

--- a/bootstrap/unix-48/extTools.c
+++ b/bootstrap/unix-48/extTools.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Configuration.h"
 #include "Console.h"

--- a/bootstrap/unix-48/extTools.h
+++ b/bootstrap/unix-48/extTools.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef extTools__h
 #define extTools__h

--- a/bootstrap/unix-48/vt100.c
+++ b/bootstrap/unix-48/vt100.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Console.h"
 #include "Strings.h"

--- a/bootstrap/unix-48/vt100.h
+++ b/bootstrap/unix-48/vt100.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef vt100__h
 #define vt100__h

--- a/bootstrap/unix-88/Configuration.c
+++ b/bootstrap/unix-88/Configuration.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 
@@ -14,6 +14,6 @@ export void *Configuration__init(void)
 	__DEFMOD;
 	__REGMOD("Configuration", 0);
 /* BEGIN */
-	__MOVE("1.95 [2016/07/19] for gcc LP64 on cygwin", Configuration_versionLong, 41);
+	__MOVE("1.95 [2016/07/21] for gcc LP64 on cygwin", Configuration_versionLong, 41);
 	__ENDMOD;
 }

--- a/bootstrap/unix-88/Configuration.h
+++ b/bootstrap/unix-88/Configuration.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Configuration__h
 #define Configuration__h

--- a/bootstrap/unix-88/Console.c
+++ b/bootstrap/unix-88/Console.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "Platform.h"

--- a/bootstrap/unix-88/Console.h
+++ b/bootstrap/unix-88/Console.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Console__h
 #define Console__h

--- a/bootstrap/unix-88/Files.h
+++ b/bootstrap/unix-88/Files.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 
 #ifndef Files__h
 #define Files__h
@@ -7,14 +7,14 @@
 #include "SYSTEM.h"
 
 typedef
-	struct Files_Handle *Files_File;
+	struct Files_FileDesc *Files_File;
 
 typedef
-	struct Files_Handle {
+	struct Files_FileDesc {
 		char _prvt0[232];
 		LONGINT fd;
-		char _prvt1[56];
-	} Files_Handle;
+		char _prvt1[64];
+	} Files_FileDesc;
 
 typedef
 	struct Files_Rider {
@@ -25,7 +25,7 @@ typedef
 
 
 
-import LONGINT *Files_Handle__typ;
+import LONGINT *Files_FileDesc__typ;
 import LONGINT *Files_Rider__typ;
 
 import Files_File Files_Base (Files_Rider *r, LONGINT *r__typ);

--- a/bootstrap/unix-88/Heap.c
+++ b/bootstrap/unix-88/Heap.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tskSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tskSfF */
 #define LARGE
 #include "SYSTEM.h"
 

--- a/bootstrap/unix-88/Heap.h
+++ b/bootstrap/unix-88/Heap.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tskSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tskSfF */
 
 #ifndef Heap__h
 #define Heap__h

--- a/bootstrap/unix-88/Modules.c
+++ b/bootstrap/unix-88/Modules.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "Console.h"

--- a/bootstrap/unix-88/Modules.h
+++ b/bootstrap/unix-88/Modules.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Modules__h
 #define Modules__h

--- a/bootstrap/unix-88/OPB.c
+++ b/bootstrap/unix-88/OPB.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "OPM.h"

--- a/bootstrap/unix-88/OPB.h
+++ b/bootstrap/unix-88/OPB.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPB__h
 #define OPB__h

--- a/bootstrap/unix-88/OPC.c
+++ b/bootstrap/unix-88/OPC.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "Configuration.h"

--- a/bootstrap/unix-88/OPC.h
+++ b/bootstrap/unix-88/OPC.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPC__h
 #define OPC__h

--- a/bootstrap/unix-88/OPM.c
+++ b/bootstrap/unix-88/OPM.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "Configuration.h"

--- a/bootstrap/unix-88/OPM.h
+++ b/bootstrap/unix-88/OPM.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPM__h
 #define OPM__h

--- a/bootstrap/unix-88/OPP.c
+++ b/bootstrap/unix-88/OPP.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "OPB.h"

--- a/bootstrap/unix-88/OPP.h
+++ b/bootstrap/unix-88/OPP.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPP__h
 #define OPP__h

--- a/bootstrap/unix-88/OPS.c
+++ b/bootstrap/unix-88/OPS.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "OPM.h"

--- a/bootstrap/unix-88/OPS.h
+++ b/bootstrap/unix-88/OPS.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 
 #ifndef OPS__h
 #define OPS__h

--- a/bootstrap/unix-88/OPT.c
+++ b/bootstrap/unix-88/OPT.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "OPM.h"

--- a/bootstrap/unix-88/OPT.h
+++ b/bootstrap/unix-88/OPT.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPT__h
 #define OPT__h

--- a/bootstrap/unix-88/OPV.c
+++ b/bootstrap/unix-88/OPV.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "OPC.h"

--- a/bootstrap/unix-88/OPV.h
+++ b/bootstrap/unix-88/OPV.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPV__h
 #define OPV__h

--- a/bootstrap/unix-88/Platform.c
+++ b/bootstrap/unix-88/Platform.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 

--- a/bootstrap/unix-88/Platform.h
+++ b/bootstrap/unix-88/Platform.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Platform__h
 #define Platform__h

--- a/bootstrap/unix-88/Reals.c
+++ b/bootstrap/unix-88/Reals.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 

--- a/bootstrap/unix-88/Reals.h
+++ b/bootstrap/unix-88/Reals.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Reals__h
 #define Reals__h

--- a/bootstrap/unix-88/Strings.c
+++ b/bootstrap/unix-88/Strings.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 

--- a/bootstrap/unix-88/Strings.h
+++ b/bootstrap/unix-88/Strings.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Strings__h
 #define Strings__h

--- a/bootstrap/unix-88/Texts.c
+++ b/bootstrap/unix-88/Texts.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "Files.h"

--- a/bootstrap/unix-88/Texts.h
+++ b/bootstrap/unix-88/Texts.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Texts__h
 #define Texts__h

--- a/bootstrap/unix-88/Vishap.c
+++ b/bootstrap/unix-88/Vishap.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkamSf */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkamSf */
 #define LARGE
 #include "SYSTEM.h"
 #include "Configuration.h"

--- a/bootstrap/unix-88/errors.c
+++ b/bootstrap/unix-88/errors.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 

--- a/bootstrap/unix-88/errors.h
+++ b/bootstrap/unix-88/errors.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef errors__h
 #define errors__h

--- a/bootstrap/unix-88/extTools.c
+++ b/bootstrap/unix-88/extTools.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "Configuration.h"

--- a/bootstrap/unix-88/extTools.h
+++ b/bootstrap/unix-88/extTools.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef extTools__h
 #define extTools__h

--- a/bootstrap/unix-88/vt100.c
+++ b/bootstrap/unix-88/vt100.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "Console.h"

--- a/bootstrap/unix-88/vt100.h
+++ b/bootstrap/unix-88/vt100.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef vt100__h
 #define vt100__h

--- a/bootstrap/windows-48/Configuration.c
+++ b/bootstrap/windows-48/Configuration.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 
 
@@ -13,6 +13,6 @@ export void *Configuration__init(void)
 	__DEFMOD;
 	__REGMOD("Configuration", 0);
 /* BEGIN */
-	__MOVE("1.95 [2016/07/19] for gcc LP64 on cygwin", Configuration_versionLong, 41);
+	__MOVE("1.95 [2016/07/21] for gcc LP64 on cygwin", Configuration_versionLong, 41);
 	__ENDMOD;
 }

--- a/bootstrap/windows-48/Configuration.h
+++ b/bootstrap/windows-48/Configuration.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Configuration__h
 #define Configuration__h

--- a/bootstrap/windows-48/Console.c
+++ b/bootstrap/windows-48/Console.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Platform.h"
 

--- a/bootstrap/windows-48/Console.h
+++ b/bootstrap/windows-48/Console.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Console__h
 #define Console__h

--- a/bootstrap/windows-48/Files.c
+++ b/bootstrap/windows-48/Files.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 #include "SYSTEM.h"
 #include "Configuration.h"
 #include "Console.h"
@@ -7,7 +7,7 @@
 #include "Strings.h"
 
 typedef
-	struct Files_Handle *Files_File;
+	struct Files_FileDesc *Files_File;
 
 typedef
 	struct Files_BufDesc {
@@ -24,14 +24,15 @@ typedef
 	CHAR Files_FileName[101];
 
 typedef
-	struct Files_Handle {
+	struct Files_FileDesc {
 		Files_FileName workName, registerName;
 		BOOLEAN tempFile;
 		Platform_FileIdentity identity;
 		LONGINT fd, len, pos;
 		Files_Buffer bufs[4];
 		INTEGER swapper, state;
-	} Files_Handle;
+		Files_File next;
+	} Files_FileDesc;
 
 typedef
 	struct Files_Rider {
@@ -42,7 +43,7 @@ typedef
 	} Files_Rider;
 
 
-static LONGINT Files_fileTab[256];
+static Files_File Files_files;
 static INTEGER Files_tempno;
 static CHAR Files_HOME[1024];
 static struct {
@@ -50,7 +51,7 @@ static struct {
 	CHAR data[1];
 } *Files_SearchPath;
 
-export LONGINT *Files_Handle__typ;
+export LONGINT *Files_FileDesc__typ;
 export LONGINT *Files_BufDesc__typ;
 export LONGINT *Files_Rider__typ;
 
@@ -58,6 +59,7 @@ export Files_File Files_Base (Files_Rider *r, LONGINT *r__typ);
 static Files_File Files_CacheEntry (Platform_FileIdentity identity);
 export void Files_ChangeDirectory (CHAR *path, LONGINT path__len, INTEGER *res);
 export void Files_Close (Files_File f);
+static void Files_CloseOSFile (Files_File f);
 static void Files_Create (Files_File f);
 export void Files_Delete (CHAR *name, LONGINT name__len, INTEGER *res);
 static void Files_Err (CHAR *s, LONGINT s__len, Files_File f, INTEGER errcode);
@@ -68,7 +70,6 @@ export void Files_GetDate (Files_File f, LONGINT *t, LONGINT *d);
 export void Files_GetName (Files_File f, CHAR *name, LONGINT name__len);
 static void Files_GetTempName (CHAR *finalName, LONGINT finalName__len, CHAR *name, LONGINT name__len);
 static BOOLEAN Files_HasDir (CHAR *name, LONGINT name__len);
-static void Files_Init (void);
 export LONGINT Files_Length (Files_File f);
 static void Files_MakeFileName (CHAR *dir, LONGINT dir__len, CHAR *name, LONGINT name__len, CHAR *dest, LONGINT dest__len);
 export Files_File Files_New (CHAR *name, LONGINT name__len);
@@ -225,26 +226,14 @@ static void Files_Create (Files_File f)
 		error = Platform_Unlink((void*)f->workName, ((LONGINT)(101)));
 		error = Platform_New((void*)f->workName, ((LONGINT)(101)), &f->fd);
 		done = error == 0;
-		if ((!done && Platform_TooManyFiles(error)) || (done && f->fd >= 256)) {
-			if ((done && f->fd >= 256)) {
-				error = Platform_Close(f->fd);
-			}
-			Heap_GC(1);
-			error = Platform_New((void*)f->workName, ((LONGINT)(101)), &f->fd);
-			done = f->fd == 0;
-		}
 		if (done) {
-			if (f->fd >= 256) {
-				error = Platform_Close(f->fd);
-				Files_Err((CHAR*)"too many files open", (LONGINT)20, f, 0);
-			} else {
-				Files_fileTab[f->fd] = (LONGINT)(uintptr_t)f;
-				Heap_FileCount += 1;
-				Heap_RegisterFinalizer((void*)f, Files_Finalize);
-				f->state = 0;
-				f->pos = 0;
-				error = Platform_Identify(f->fd, &f->identity, Platform_FileIdentity__typ);
-			}
+			f->next = Files_files;
+			Files_files = f;
+			Heap_FileCount += 1;
+			Heap_RegisterFinalizer((void*)f, Files_Finalize);
+			f->state = 0;
+			f->pos = 0;
+			error = Platform_Identify(f->fd, &f->identity, Platform_FileIdentity__typ);
 		} else {
 			if (Platform_NoSuchDirectory(error)) {
 				__MOVE("no such directory", err, 18);
@@ -281,6 +270,27 @@ static void Files_Flush (Files_Buffer buf)
 	}
 }
 
+static void Files_CloseOSFile (Files_File f)
+{
+	Files_File prev = NIL;
+	INTEGER error;
+	if (Files_files == f) {
+		Files_files = f->next;
+	} else {
+		prev = Files_files;
+		while ((prev != NIL && prev->next != f)) {
+			prev = prev->next;
+		}
+		if (prev->next != NIL) {
+			prev->next = f->next;
+		}
+	}
+	error = Platform_Close(f->fd);
+	f->fd = -1;
+	f->state = 1;
+	Heap_FileCount -= 1;
+}
+
 void Files_Close (Files_File f)
 {
 	LONGINT i;
@@ -296,11 +306,7 @@ void Files_Close (Files_File f)
 		if (error != 0) {
 			Files_Err((CHAR*)"error writing file", (LONGINT)19, f, error);
 		}
-		Files_fileTab[f->fd] = 0;
-		error = Platform_Close(f->fd);
-		f->fd = -1;
-		f->state = 1;
-		Heap_FileCount -= 1;
+		Files_CloseOSFile(f);
 	}
 }
 
@@ -316,7 +322,7 @@ Files_File Files_New (CHAR *name, LONGINT name__len)
 	Files_File _o_result;
 	Files_File f = NIL;
 	__DUP(name, name__len, CHAR);
-	__NEW(f, Files_Handle);
+	__NEW(f, Files_FileDesc);
 	f->workName[0] = 0x00;
 	__COPY(name, f->registerName, ((LONGINT)(101)));
 	f->fd = -1;
@@ -392,10 +398,9 @@ static Files_File Files_CacheEntry (Platform_FileIdentity identity)
 	Files_File _o_result;
 	Files_File f = NIL;
 	INTEGER i, error;
-	i = 0;
-	while (i < 256) {
-		f = (Files_File)(uintptr_t)Files_fileTab[i];
-		if ((f != NIL && Platform_SameFile(identity, f->identity))) {
+	f = Files_files;
+	while (f != NIL) {
+		if (Platform_SameFile(identity, f->identity)) {
 			if (!Platform_SameFileTime(identity, f->identity)) {
 				i = 0;
 				while (i < 4) {
@@ -412,7 +417,7 @@ static Files_File Files_CacheEntry (Platform_FileIdentity identity)
 			_o_result = f;
 			return _o_result;
 		}
-		i += 1;
+		f = f->next;
 	}
 	_o_result = NIL;
 	return _o_result;
@@ -442,16 +447,8 @@ Files_File Files_Old (CHAR *name, LONGINT name__len)
 		for (;;) {
 			error = Platform_OldRW((void*)path, ((LONGINT)(256)), &fd);
 			done = error == 0;
-			if ((!done && Platform_TooManyFiles(error)) || (done && fd >= 256)) {
-				if ((done && fd >= 256)) {
-					error = Platform_Close(fd);
-				}
-				Heap_GC(1);
-				error = Platform_OldRW((void*)path, ((LONGINT)(256)), &fd);
-				done = error == 0;
-				if ((!done && Platform_TooManyFiles(error))) {
-					Files_Err((CHAR*)"too many files open", (LONGINT)20, f, error);
-				}
+			if ((!done && Platform_TooManyFiles(error))) {
+				Files_Err((CHAR*)"too many files open", (LONGINT)20, f, error);
 			}
 			if ((!done && Platform_Inaccessible(error))) {
 				error = Platform_OldRO((void*)path, ((LONGINT)(256)), &fd);
@@ -468,17 +465,11 @@ Files_File Files_Old (CHAR *name, LONGINT name__len)
 				error = Platform_Identify(fd, &identity, Platform_FileIdentity__typ);
 				f = Files_CacheEntry(identity);
 				if (f != NIL) {
-					error = Platform_Close(fd);
 					_o_result = f;
 					__DEL(name);
 					return _o_result;
-				} else if (fd >= 256) {
-					error = Platform_Close(fd);
-					Files_Err((CHAR*)"too many files open", (LONGINT)20, f, 0);
 				} else {
-					__NEW(f, Files_Handle);
-					Files_fileTab[fd] = (LONGINT)(uintptr_t)f;
-					Heap_FileCount += 1;
+					__NEW(f, Files_FileDesc);
 					Heap_RegisterFinalizer((void*)f, Files_Finalize);
 					f->fd = fd;
 					f->state = 0;
@@ -489,6 +480,9 @@ Files_File Files_Old (CHAR *name, LONGINT name__len)
 					f->registerName[0] = 0x00;
 					f->tempFile = 0;
 					f->identity = identity;
+					f->next = Files_files;
+					Files_files = f;
+					Heap_FileCount += 1;
 					_o_result = f;
 					__DEL(name);
 					return _o_result;
@@ -1014,10 +1008,7 @@ static void Files_Finalize (SYSTEM_PTR o)
 	LONGINT res;
 	f = (Files_File)(uintptr_t)o;
 	if (f->fd >= 0) {
-		Files_fileTab[f->fd] = 0;
-		res = Platform_Close(f->fd);
-		f->fd = -1;
-		Heap_FileCount -= 1;
+		Files_CloseOSFile(f);
 		if (f->tempFile) {
 			res = Platform_Unlink((void*)f->workName, ((LONGINT)(101)));
 		}
@@ -1036,27 +1027,13 @@ void Files_SetSearchPath (CHAR *path, LONGINT path__len)
 	__DEL(path);
 }
 
-static void Files_Init (void)
-{
-	LONGINT i;
-	i = 0;
-	while (i < 256) {
-		Files_fileTab[i] = 0;
-		i += 1;
-	}
-	Files_tempno = -1;
-	Heap_FileCount = 0;
-	Files_SearchPath = NIL;
-	Files_HOME[0] = 0x00;
-	Platform_GetEnv((CHAR*)"HOME", (LONGINT)5, (void*)Files_HOME, ((LONGINT)(1024)));
-}
-
 static void EnumPtrs(void (*P)(void*))
 {
+	P(Files_files);
 	P(Files_SearchPath);
 }
 
-__TDESC(Files_Handle, 1, 4) = {__TDFLDS("Handle", 256), {236, 240, 244, 248, -20}};
+__TDESC(Files_FileDesc, 1, 5) = {__TDFLDS("FileDesc", 260), {236, 240, 244, 248, 256, -24}};
 __TDESC(Files_BufDesc, 1, 1) = {__TDFLDS("BufDesc", 4112), {0, -8}};
 __TDESC(Files_Rider, 1, 1) = {__TDFLDS("Rider", 20), {8, -8}};
 
@@ -1069,10 +1046,13 @@ export void *Files__init(void)
 	__MODULE_IMPORT(Platform);
 	__MODULE_IMPORT(Strings);
 	__REGMOD("Files", EnumPtrs);
-	__INITYP(Files_Handle, Files_Handle, 0);
+	__INITYP(Files_FileDesc, Files_FileDesc, 0);
 	__INITYP(Files_BufDesc, Files_BufDesc, 0);
 	__INITYP(Files_Rider, Files_Rider, 0);
 /* BEGIN */
-	Files_Init();
+	Files_tempno = -1;
+	Heap_FileCount = 0;
+	Files_HOME[0] = 0x00;
+	Platform_GetEnv((CHAR*)"HOME", (LONGINT)5, (void*)Files_HOME, ((LONGINT)(1024)));
 	__ENDMOD;
 }

--- a/bootstrap/windows-48/Files.h
+++ b/bootstrap/windows-48/Files.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 
 #ifndef Files__h
 #define Files__h
@@ -6,14 +6,14 @@
 #include "SYSTEM.h"
 
 typedef
-	struct Files_Handle *Files_File;
+	struct Files_FileDesc *Files_File;
 
 typedef
-	struct Files_Handle {
+	struct Files_FileDesc {
 		char _prvt0[224];
 		LONGINT fd;
-		char _prvt1[28];
-	} Files_Handle;
+		char _prvt1[32];
+	} Files_FileDesc;
 
 typedef
 	struct Files_Rider {
@@ -24,7 +24,7 @@ typedef
 
 
 
-import LONGINT *Files_Handle__typ;
+import LONGINT *Files_FileDesc__typ;
 import LONGINT *Files_Rider__typ;
 
 import Files_File Files_Base (Files_Rider *r, LONGINT *r__typ);

--- a/bootstrap/windows-48/Heap.c
+++ b/bootstrap/windows-48/Heap.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tskSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tskSfF */
 #include "SYSTEM.h"
 
 struct Heap__1 {

--- a/bootstrap/windows-48/Heap.h
+++ b/bootstrap/windows-48/Heap.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tskSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tskSfF */
 
 #ifndef Heap__h
 #define Heap__h

--- a/bootstrap/windows-48/Modules.c
+++ b/bootstrap/windows-48/Modules.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Console.h"
 #include "Heap.h"

--- a/bootstrap/windows-48/Modules.h
+++ b/bootstrap/windows-48/Modules.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Modules__h
 #define Modules__h

--- a/bootstrap/windows-48/OPB.c
+++ b/bootstrap/windows-48/OPB.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "OPM.h"
 #include "OPS.h"

--- a/bootstrap/windows-48/OPB.h
+++ b/bootstrap/windows-48/OPB.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPB__h
 #define OPB__h

--- a/bootstrap/windows-48/OPC.c
+++ b/bootstrap/windows-48/OPC.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Configuration.h"
 #include "OPM.h"

--- a/bootstrap/windows-48/OPC.h
+++ b/bootstrap/windows-48/OPC.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPC__h
 #define OPC__h

--- a/bootstrap/windows-48/OPM.c
+++ b/bootstrap/windows-48/OPM.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Configuration.h"
 #include "Console.h"

--- a/bootstrap/windows-48/OPM.h
+++ b/bootstrap/windows-48/OPM.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPM__h
 #define OPM__h

--- a/bootstrap/windows-48/OPP.c
+++ b/bootstrap/windows-48/OPP.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "OPB.h"
 #include "OPM.h"

--- a/bootstrap/windows-48/OPP.h
+++ b/bootstrap/windows-48/OPP.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPP__h
 #define OPP__h

--- a/bootstrap/windows-48/OPS.c
+++ b/bootstrap/windows-48/OPS.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 #include "SYSTEM.h"
 #include "OPM.h"
 

--- a/bootstrap/windows-48/OPS.h
+++ b/bootstrap/windows-48/OPS.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 
 #ifndef OPS__h
 #define OPS__h

--- a/bootstrap/windows-48/OPT.c
+++ b/bootstrap/windows-48/OPT.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "OPM.h"
 #include "OPS.h"

--- a/bootstrap/windows-48/OPT.h
+++ b/bootstrap/windows-48/OPT.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPT__h
 #define OPT__h

--- a/bootstrap/windows-48/OPV.c
+++ b/bootstrap/windows-48/OPV.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "OPC.h"
 #include "OPM.h"

--- a/bootstrap/windows-48/OPV.h
+++ b/bootstrap/windows-48/OPV.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPV__h
 #define OPV__h

--- a/bootstrap/windows-48/Platform.c
+++ b/bootstrap/windows-48/Platform.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 
 typedef

--- a/bootstrap/windows-48/Platform.h
+++ b/bootstrap/windows-48/Platform.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Platform__h
 #define Platform__h

--- a/bootstrap/windows-48/Reals.c
+++ b/bootstrap/windows-48/Reals.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 
 

--- a/bootstrap/windows-48/Reals.h
+++ b/bootstrap/windows-48/Reals.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Reals__h
 #define Reals__h

--- a/bootstrap/windows-48/Strings.c
+++ b/bootstrap/windows-48/Strings.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 
 

--- a/bootstrap/windows-48/Strings.h
+++ b/bootstrap/windows-48/Strings.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Strings__h
 #define Strings__h

--- a/bootstrap/windows-48/Texts.c
+++ b/bootstrap/windows-48/Texts.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Files.h"
 #include "Modules.h"

--- a/bootstrap/windows-48/Texts.h
+++ b/bootstrap/windows-48/Texts.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Texts__h
 #define Texts__h

--- a/bootstrap/windows-48/Vishap.c
+++ b/bootstrap/windows-48/Vishap.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkamSf */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkamSf */
 #include "SYSTEM.h"
 #include "Configuration.h"
 #include "Heap.h"

--- a/bootstrap/windows-48/errors.c
+++ b/bootstrap/windows-48/errors.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 
 typedef

--- a/bootstrap/windows-48/errors.h
+++ b/bootstrap/windows-48/errors.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef errors__h
 #define errors__h

--- a/bootstrap/windows-48/extTools.c
+++ b/bootstrap/windows-48/extTools.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Configuration.h"
 #include "Console.h"

--- a/bootstrap/windows-48/extTools.h
+++ b/bootstrap/windows-48/extTools.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef extTools__h
 #define extTools__h

--- a/bootstrap/windows-48/vt100.c
+++ b/bootstrap/windows-48/vt100.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #include "SYSTEM.h"
 #include "Console.h"
 #include "Strings.h"

--- a/bootstrap/windows-48/vt100.h
+++ b/bootstrap/windows-48/vt100.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef vt100__h
 #define vt100__h

--- a/bootstrap/windows-88/Configuration.c
+++ b/bootstrap/windows-88/Configuration.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 
@@ -14,6 +14,6 @@ export void *Configuration__init(void)
 	__DEFMOD;
 	__REGMOD("Configuration", 0);
 /* BEGIN */
-	__MOVE("1.95 [2016/07/19] for gcc LP64 on cygwin", Configuration_versionLong, 41);
+	__MOVE("1.95 [2016/07/21] for gcc LP64 on cygwin", Configuration_versionLong, 41);
 	__ENDMOD;
 }

--- a/bootstrap/windows-88/Configuration.h
+++ b/bootstrap/windows-88/Configuration.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Configuration__h
 #define Configuration__h

--- a/bootstrap/windows-88/Console.c
+++ b/bootstrap/windows-88/Console.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "Platform.h"

--- a/bootstrap/windows-88/Console.h
+++ b/bootstrap/windows-88/Console.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Console__h
 #define Console__h

--- a/bootstrap/windows-88/Files.c
+++ b/bootstrap/windows-88/Files.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "Configuration.h"
@@ -8,7 +8,7 @@
 #include "Strings.h"
 
 typedef
-	struct Files_Handle *Files_File;
+	struct Files_FileDesc *Files_File;
 
 typedef
 	struct Files_BufDesc {
@@ -25,14 +25,15 @@ typedef
 	CHAR Files_FileName[101];
 
 typedef
-	struct Files_Handle {
+	struct Files_FileDesc {
 		Files_FileName workName, registerName;
 		BOOLEAN tempFile;
 		Platform_FileIdentity identity;
 		LONGINT fd, len, pos;
 		Files_Buffer bufs[4];
 		INTEGER swapper, state;
-	} Files_Handle;
+		Files_File next;
+	} Files_FileDesc;
 
 typedef
 	struct Files_Rider {
@@ -43,7 +44,7 @@ typedef
 	} Files_Rider;
 
 
-static LONGINT Files_fileTab[256];
+static Files_File Files_files;
 static INTEGER Files_tempno;
 static CHAR Files_HOME[1024];
 static struct {
@@ -51,7 +52,7 @@ static struct {
 	CHAR data[1];
 } *Files_SearchPath;
 
-export LONGINT *Files_Handle__typ;
+export LONGINT *Files_FileDesc__typ;
 export LONGINT *Files_BufDesc__typ;
 export LONGINT *Files_Rider__typ;
 
@@ -59,6 +60,7 @@ export Files_File Files_Base (Files_Rider *r, LONGINT *r__typ);
 static Files_File Files_CacheEntry (Platform_FileIdentity identity);
 export void Files_ChangeDirectory (CHAR *path, LONGINT path__len, INTEGER *res);
 export void Files_Close (Files_File f);
+static void Files_CloseOSFile (Files_File f);
 static void Files_Create (Files_File f);
 export void Files_Delete (CHAR *name, LONGINT name__len, INTEGER *res);
 static void Files_Err (CHAR *s, LONGINT s__len, Files_File f, INTEGER errcode);
@@ -69,7 +71,6 @@ export void Files_GetDate (Files_File f, LONGINT *t, LONGINT *d);
 export void Files_GetName (Files_File f, CHAR *name, LONGINT name__len);
 static void Files_GetTempName (CHAR *finalName, LONGINT finalName__len, CHAR *name, LONGINT name__len);
 static BOOLEAN Files_HasDir (CHAR *name, LONGINT name__len);
-static void Files_Init (void);
 export LONGINT Files_Length (Files_File f);
 static void Files_MakeFileName (CHAR *dir, LONGINT dir__len, CHAR *name, LONGINT name__len, CHAR *dest, LONGINT dest__len);
 export Files_File Files_New (CHAR *name, LONGINT name__len);
@@ -226,26 +227,14 @@ static void Files_Create (Files_File f)
 		error = Platform_Unlink((void*)f->workName, ((LONGINT)(101)));
 		error = Platform_New((void*)f->workName, ((LONGINT)(101)), &f->fd);
 		done = error == 0;
-		if ((!done && Platform_TooManyFiles(error)) || (done && f->fd >= 256)) {
-			if ((done && f->fd >= 256)) {
-				error = Platform_Close(f->fd);
-			}
-			Heap_GC(1);
-			error = Platform_New((void*)f->workName, ((LONGINT)(101)), &f->fd);
-			done = f->fd == 0;
-		}
 		if (done) {
-			if (f->fd >= 256) {
-				error = Platform_Close(f->fd);
-				Files_Err((CHAR*)"too many files open", (LONGINT)20, f, 0);
-			} else {
-				Files_fileTab[f->fd] = (LONGINT)(uintptr_t)f;
-				Heap_FileCount += 1;
-				Heap_RegisterFinalizer((void*)f, Files_Finalize);
-				f->state = 0;
-				f->pos = 0;
-				error = Platform_Identify(f->fd, &f->identity, Platform_FileIdentity__typ);
-			}
+			f->next = Files_files;
+			Files_files = f;
+			Heap_FileCount += 1;
+			Heap_RegisterFinalizer((void*)f, Files_Finalize);
+			f->state = 0;
+			f->pos = 0;
+			error = Platform_Identify(f->fd, &f->identity, Platform_FileIdentity__typ);
 		} else {
 			if (Platform_NoSuchDirectory(error)) {
 				__MOVE("no such directory", err, 18);
@@ -282,6 +271,27 @@ static void Files_Flush (Files_Buffer buf)
 	}
 }
 
+static void Files_CloseOSFile (Files_File f)
+{
+	Files_File prev = NIL;
+	INTEGER error;
+	if (Files_files == f) {
+		Files_files = f->next;
+	} else {
+		prev = Files_files;
+		while ((prev != NIL && prev->next != f)) {
+			prev = prev->next;
+		}
+		if (prev->next != NIL) {
+			prev->next = f->next;
+		}
+	}
+	error = Platform_Close(f->fd);
+	f->fd = -1;
+	f->state = 1;
+	Heap_FileCount -= 1;
+}
+
 void Files_Close (Files_File f)
 {
 	LONGINT i;
@@ -297,11 +307,7 @@ void Files_Close (Files_File f)
 		if (error != 0) {
 			Files_Err((CHAR*)"error writing file", (LONGINT)19, f, error);
 		}
-		Files_fileTab[f->fd] = 0;
-		error = Platform_Close(f->fd);
-		f->fd = -1;
-		f->state = 1;
-		Heap_FileCount -= 1;
+		Files_CloseOSFile(f);
 	}
 }
 
@@ -317,7 +323,7 @@ Files_File Files_New (CHAR *name, LONGINT name__len)
 	Files_File _o_result;
 	Files_File f = NIL;
 	__DUP(name, name__len, CHAR);
-	__NEW(f, Files_Handle);
+	__NEW(f, Files_FileDesc);
 	f->workName[0] = 0x00;
 	__COPY(name, f->registerName, ((LONGINT)(101)));
 	f->fd = -1;
@@ -393,10 +399,9 @@ static Files_File Files_CacheEntry (Platform_FileIdentity identity)
 	Files_File _o_result;
 	Files_File f = NIL;
 	INTEGER i, error;
-	i = 0;
-	while (i < 256) {
-		f = (Files_File)(uintptr_t)Files_fileTab[i];
-		if ((f != NIL && Platform_SameFile(identity, f->identity))) {
+	f = Files_files;
+	while (f != NIL) {
+		if (Platform_SameFile(identity, f->identity)) {
 			if (!Platform_SameFileTime(identity, f->identity)) {
 				i = 0;
 				while (i < 4) {
@@ -413,7 +418,7 @@ static Files_File Files_CacheEntry (Platform_FileIdentity identity)
 			_o_result = f;
 			return _o_result;
 		}
-		i += 1;
+		f = f->next;
 	}
 	_o_result = NIL;
 	return _o_result;
@@ -443,16 +448,8 @@ Files_File Files_Old (CHAR *name, LONGINT name__len)
 		for (;;) {
 			error = Platform_OldRW((void*)path, ((LONGINT)(256)), &fd);
 			done = error == 0;
-			if ((!done && Platform_TooManyFiles(error)) || (done && fd >= 256)) {
-				if ((done && fd >= 256)) {
-					error = Platform_Close(fd);
-				}
-				Heap_GC(1);
-				error = Platform_OldRW((void*)path, ((LONGINT)(256)), &fd);
-				done = error == 0;
-				if ((!done && Platform_TooManyFiles(error))) {
-					Files_Err((CHAR*)"too many files open", (LONGINT)20, f, error);
-				}
+			if ((!done && Platform_TooManyFiles(error))) {
+				Files_Err((CHAR*)"too many files open", (LONGINT)20, f, error);
 			}
 			if ((!done && Platform_Inaccessible(error))) {
 				error = Platform_OldRO((void*)path, ((LONGINT)(256)), &fd);
@@ -469,17 +466,11 @@ Files_File Files_Old (CHAR *name, LONGINT name__len)
 				error = Platform_Identify(fd, &identity, Platform_FileIdentity__typ);
 				f = Files_CacheEntry(identity);
 				if (f != NIL) {
-					error = Platform_Close(fd);
 					_o_result = f;
 					__DEL(name);
 					return _o_result;
-				} else if (fd >= 256) {
-					error = Platform_Close(fd);
-					Files_Err((CHAR*)"too many files open", (LONGINT)20, f, 0);
 				} else {
-					__NEW(f, Files_Handle);
-					Files_fileTab[fd] = (LONGINT)(uintptr_t)f;
-					Heap_FileCount += 1;
+					__NEW(f, Files_FileDesc);
 					Heap_RegisterFinalizer((void*)f, Files_Finalize);
 					f->fd = fd;
 					f->state = 0;
@@ -490,6 +481,9 @@ Files_File Files_Old (CHAR *name, LONGINT name__len)
 					f->registerName[0] = 0x00;
 					f->tempFile = 0;
 					f->identity = identity;
+					f->next = Files_files;
+					Files_files = f;
+					Heap_FileCount += 1;
 					_o_result = f;
 					__DEL(name);
 					return _o_result;
@@ -1015,10 +1009,7 @@ static void Files_Finalize (SYSTEM_PTR o)
 	LONGINT res;
 	f = (Files_File)(uintptr_t)o;
 	if (f->fd >= 0) {
-		Files_fileTab[f->fd] = 0;
-		res = Platform_Close(f->fd);
-		f->fd = -1;
-		Heap_FileCount -= 1;
+		Files_CloseOSFile(f);
 		if (f->tempFile) {
 			res = Platform_Unlink((void*)f->workName, ((LONGINT)(101)));
 		}
@@ -1037,27 +1028,13 @@ void Files_SetSearchPath (CHAR *path, LONGINT path__len)
 	__DEL(path);
 }
 
-static void Files_Init (void)
-{
-	LONGINT i;
-	i = 0;
-	while (i < 256) {
-		Files_fileTab[i] = 0;
-		i += 1;
-	}
-	Files_tempno = -1;
-	Heap_FileCount = 0;
-	Files_SearchPath = NIL;
-	Files_HOME[0] = 0x00;
-	Platform_GetEnv((CHAR*)"HOME", (LONGINT)5, (void*)Files_HOME, ((LONGINT)(1024)));
-}
-
 static void EnumPtrs(void (*P)(void*))
 {
+	P(Files_files);
 	P(Files_SearchPath);
 }
 
-__TDESC(Files_Handle, 1, 4) = {__TDFLDS("Handle", 312), {272, 280, 288, 296, -40}};
+__TDESC(Files_FileDesc, 1, 5) = {__TDFLDS("FileDesc", 320), {272, 280, 288, 296, 312, -48}};
 __TDESC(Files_BufDesc, 1, 1) = {__TDFLDS("BufDesc", 4128), {0, -16}};
 __TDESC(Files_Rider, 1, 1) = {__TDFLDS("Rider", 40), {16, -16}};
 
@@ -1070,10 +1047,13 @@ export void *Files__init(void)
 	__MODULE_IMPORT(Platform);
 	__MODULE_IMPORT(Strings);
 	__REGMOD("Files", EnumPtrs);
-	__INITYP(Files_Handle, Files_Handle, 0);
+	__INITYP(Files_FileDesc, Files_FileDesc, 0);
 	__INITYP(Files_BufDesc, Files_BufDesc, 0);
 	__INITYP(Files_Rider, Files_Rider, 0);
 /* BEGIN */
-	Files_Init();
+	Files_tempno = -1;
+	Heap_FileCount = 0;
+	Files_HOME[0] = 0x00;
+	Platform_GetEnv((CHAR*)"HOME", (LONGINT)5, (void*)Files_HOME, ((LONGINT)(1024)));
 	__ENDMOD;
 }

--- a/bootstrap/windows-88/Files.h
+++ b/bootstrap/windows-88/Files.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 
 #ifndef Files__h
 #define Files__h
@@ -7,14 +7,14 @@
 #include "SYSTEM.h"
 
 typedef
-	struct Files_Handle *Files_File;
+	struct Files_FileDesc *Files_File;
 
 typedef
-	struct Files_Handle {
+	struct Files_FileDesc {
 		char _prvt0[248];
 		LONGINT fd;
-		char _prvt1[56];
-	} Files_Handle;
+		char _prvt1[64];
+	} Files_FileDesc;
 
 typedef
 	struct Files_Rider {
@@ -25,7 +25,7 @@ typedef
 
 
 
-import LONGINT *Files_Handle__typ;
+import LONGINT *Files_FileDesc__typ;
 import LONGINT *Files_Rider__typ;
 
 import Files_File Files_Base (Files_Rider *r, LONGINT *r__typ);

--- a/bootstrap/windows-88/Heap.c
+++ b/bootstrap/windows-88/Heap.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tskSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tskSfF */
 #define LARGE
 #include "SYSTEM.h"
 

--- a/bootstrap/windows-88/Heap.h
+++ b/bootstrap/windows-88/Heap.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tskSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tskSfF */
 
 #ifndef Heap__h
 #define Heap__h

--- a/bootstrap/windows-88/Modules.c
+++ b/bootstrap/windows-88/Modules.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "Console.h"

--- a/bootstrap/windows-88/Modules.h
+++ b/bootstrap/windows-88/Modules.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Modules__h
 #define Modules__h

--- a/bootstrap/windows-88/OPB.c
+++ b/bootstrap/windows-88/OPB.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "OPM.h"

--- a/bootstrap/windows-88/OPB.h
+++ b/bootstrap/windows-88/OPB.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPB__h
 #define OPB__h

--- a/bootstrap/windows-88/OPC.c
+++ b/bootstrap/windows-88/OPC.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "Configuration.h"

--- a/bootstrap/windows-88/OPC.h
+++ b/bootstrap/windows-88/OPC.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPC__h
 #define OPC__h

--- a/bootstrap/windows-88/OPM.c
+++ b/bootstrap/windows-88/OPM.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "Configuration.h"

--- a/bootstrap/windows-88/OPM.h
+++ b/bootstrap/windows-88/OPM.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPM__h
 #define OPM__h

--- a/bootstrap/windows-88/OPP.c
+++ b/bootstrap/windows-88/OPP.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "OPB.h"

--- a/bootstrap/windows-88/OPP.h
+++ b/bootstrap/windows-88/OPP.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPP__h
 #define OPP__h

--- a/bootstrap/windows-88/OPS.c
+++ b/bootstrap/windows-88/OPS.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "OPM.h"

--- a/bootstrap/windows-88/OPS.h
+++ b/bootstrap/windows-88/OPS.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin tspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin tspkaSfF */
 
 #ifndef OPS__h
 #define OPS__h

--- a/bootstrap/windows-88/OPT.c
+++ b/bootstrap/windows-88/OPT.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "OPM.h"

--- a/bootstrap/windows-88/OPT.h
+++ b/bootstrap/windows-88/OPT.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPT__h
 #define OPT__h

--- a/bootstrap/windows-88/OPV.c
+++ b/bootstrap/windows-88/OPV.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "OPC.h"

--- a/bootstrap/windows-88/OPV.h
+++ b/bootstrap/windows-88/OPV.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef OPV__h
 #define OPV__h

--- a/bootstrap/windows-88/Platform.c
+++ b/bootstrap/windows-88/Platform.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 

--- a/bootstrap/windows-88/Platform.h
+++ b/bootstrap/windows-88/Platform.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Platform__h
 #define Platform__h

--- a/bootstrap/windows-88/Reals.c
+++ b/bootstrap/windows-88/Reals.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 

--- a/bootstrap/windows-88/Reals.h
+++ b/bootstrap/windows-88/Reals.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Reals__h
 #define Reals__h

--- a/bootstrap/windows-88/Strings.c
+++ b/bootstrap/windows-88/Strings.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 

--- a/bootstrap/windows-88/Strings.h
+++ b/bootstrap/windows-88/Strings.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Strings__h
 #define Strings__h

--- a/bootstrap/windows-88/Texts.c
+++ b/bootstrap/windows-88/Texts.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "Files.h"

--- a/bootstrap/windows-88/Texts.h
+++ b/bootstrap/windows-88/Texts.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef Texts__h
 #define Texts__h

--- a/bootstrap/windows-88/Vishap.c
+++ b/bootstrap/windows-88/Vishap.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkamSf */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkamSf */
 #define LARGE
 #include "SYSTEM.h"
 #include "Configuration.h"

--- a/bootstrap/windows-88/errors.c
+++ b/bootstrap/windows-88/errors.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 

--- a/bootstrap/windows-88/errors.h
+++ b/bootstrap/windows-88/errors.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef errors__h
 #define errors__h

--- a/bootstrap/windows-88/extTools.c
+++ b/bootstrap/windows-88/extTools.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "Configuration.h"

--- a/bootstrap/windows-88/extTools.h
+++ b/bootstrap/windows-88/extTools.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef extTools__h
 #define extTools__h

--- a/bootstrap/windows-88/vt100.c
+++ b/bootstrap/windows-88/vt100.c
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 #define LARGE
 #include "SYSTEM.h"
 #include "Console.h"

--- a/bootstrap/windows-88/vt100.h
+++ b/bootstrap/windows-88/vt100.h
@@ -1,4 +1,4 @@
-/* voc  1.95 [2016/07/19] for gcc LP64 on cygwin xtspkaSfF */
+/* voc  1.95 [2016/07/21] for gcc LP64 on cygwin xtspkaSfF */
 
 #ifndef vt100__h
 #define vt100__h

--- a/src/system/Files.Mod
+++ b/src/system/Files.Mod
@@ -16,7 +16,6 @@ MODULE Files;  (* J. Templ 1.12. 89/12.4.95 Oberon files mapped onto Unix files 
   CONST
     nofbufs = 4;
     bufsize = 4096;
-    fileTabSize = 256;  (* 256 needed for Windows *)
     noDesc = -1;
     notDone = -1;
 
@@ -31,17 +30,18 @@ MODULE Files;  (* J. Templ 1.12. 89/12.4.95 Oberon files mapped onto Unix files 
 
   TYPE
     FileName = ARRAY 101 OF CHAR;
-    File*    = POINTER TO Handle;
+    File*    = POINTER TO FileDesc;
     Buffer   = POINTER TO BufDesc;
 
-    Handle = RECORD
+    FileDesc = RECORD
       workName, registerName: FileName;
       tempFile: BOOLEAN;
       identity: Platform.FileIdentity;
       fd-:      Platform.FileHandle;
       len, pos: LONGINT;
       bufs: ARRAY nofbufs OF Buffer;
-      swapper, state: INTEGER
+      swapper, state: INTEGER;
+      next:     File;
     END;
 
     BufDesc = RECORD
@@ -61,7 +61,7 @@ MODULE Files;  (* J. Templ 1.12. 89/12.4.95 Oberon files mapped onto Unix files 
 
 
   VAR
-    fileTab:    ARRAY fileTabSize OF LONGINT (*=File*);
+    files:      File;   (* List of files that have an OS file handle/descriptor assigned  *)
     tempno:     INTEGER;
     HOME:       ARRAY 1024 OF CHAR;
     SearchPath: POINTER TO ARRAY OF CHAR;
@@ -137,30 +137,16 @@ MODULE Files;  (* J. Templ 1.12. 89/12.4.95 Oberon files mapped onto Unix files 
 
       error := Platform.New(f.workName, f.fd);
       done := error = 0;
-      (* In case of too many files, try just once more. *)
-      IF (~done & Platform.TooManyFiles(error)) OR (done & (f.fd >= fileTabSize)) THEN
-        IF done & (f.fd >= fileTabSize) THEN error := Platform.Close(f.fd) END;
-        Heap.GC(TRUE);
-        error := Platform.New(f.workName, f.fd);
-        done  := f.fd = 0
-      END;
       IF done THEN
-        IF f.fd >= fileTabSize THEN
-          (* Console.String("f.fd = "); Console.Int(f.fd,1); Console.Ln; *)
-          error := Platform.Close(f.fd); Err("too many files open", f, 0)
-        ELSE
-          fileTab[f.fd] := SYSTEM.VAL(LONGINT, f);
-          INC(Heap.FileCount);
-          Heap.RegisterFinalizer(f, Finalize);
-          f.state    := open;
-          f.pos      := 0;
-          error      := Platform.Identify(f.fd, f.identity);
-        END
+        f.next := files;  files := f;
+        INC(Heap.FileCount);
+        Heap.RegisterFinalizer(f, Finalize);
+        f.state := open;
+        f.pos   := 0;
+        error   := Platform.Identify(f.fd, f.identity);
       ELSE
         IF    Platform.NoSuchDirectory(error) THEN err := "no such directory"
-        ELSIF Platform.TooManyFiles(error)    THEN
-          (* Console.String("f.fd = "); Console.Int(f.fd,1); Console.Ln; *)
-          err := "too many files open"
+        ELSIF Platform.TooManyFiles(error)    THEN err := "too many files open"
         ELSE  err := "file not created"
         END;
         Err(err, f, error)
@@ -201,30 +187,33 @@ MODULE Files;  (* J. Templ 1.12. 89/12.4.95 Oberon files mapped onto Unix files 
     END
   END Flush;
 
+
+  PROCEDURE CloseOSFile(f: File);
+  (* Close the OS file handle and remove f from 'files' *)
+    VAR prev: File; error: Platform.ErrorCode;
+  BEGIN
+    IF files = f THEN files := f.next
+    ELSE
+      prev := files;
+      WHILE (prev # NIL) & (prev.next # f) DO prev := prev.next END;
+      IF prev.next # NIL THEN prev.next := f.next END
+    END;
+    error := Platform.Close(f.fd);
+    f.fd := noDesc; f.state := create; DEC(Heap.FileCount);
+  END CloseOSFile;
+
+
   PROCEDURE Close* (f: File);
     VAR
       i:     LONGINT;
       error: Platform.ErrorCode;
   BEGIN
-    (*
-    Console.String("Files.Close f.fd = "); Console.Int(f.fd,1);
-    Console.String(" f.registername = "); Console.String(f.registerName);
-    Console.String(", f.workName = "); Console.String(f.workName); Console.Ln;
-    *)
     IF (f.state # create) OR (f.registerName # "") THEN
       Create(f); i := 0;
       WHILE (i < nofbufs) & (f.bufs[i] # NIL) DO Flush(f.bufs[i]); INC(i) END;
       error := Platform.Sync(f.fd);
-      (*
-      Console.String("Syncing closed file. fd = "); Console.Int(f.fd, 1);
-      Console.String(" error = "); Console.Int(error,1); Console.Ln;
-      *)
       IF error # 0 THEN Err("error writing file", f, error) END;
-      (* Windows needs us to actually cose the file so that subsequent rename
-         will not encounter a sharing error. *)
-      fileTab[f.fd] := 0;
-      error := Platform.Close(f.fd);
-      f.fd := noDesc; f.state := create; DEC(Heap.FileCount);
+      CloseOSFile(f);
     END
   END Close;
 
@@ -275,10 +264,9 @@ MODULE Files;  (* J. Templ 1.12. 89/12.4.95 Oberon files mapped onto Unix files 
 
   PROCEDURE CacheEntry(identity: Platform.FileIdentity): File;
     VAR f: File;  i: INTEGER;  error: Platform.ErrorCode;
-  BEGIN i := 0;
-    WHILE i < fileTabSize DO
-      f := SYSTEM.VAL(File, fileTab[i]);
-      IF (f # NIL) & Platform.SameFile(identity, f.identity) THEN
+  BEGIN f := files;
+    WHILE f # NIL DO
+      IF Platform.SameFile(identity, f.identity) THEN
         IF ~Platform.SameFileTime(identity, f.identity) THEN i := 0;
           WHILE i < nofbufs DO
             IF f.bufs[i] # NIL THEN f.bufs[i].org := -1; f.bufs[i] := NIL END;
@@ -289,7 +277,7 @@ MODULE Files;  (* J. Templ 1.12. 89/12.4.95 Oberon files mapped onto Unix files 
         END;
         RETURN f
       END;
-      INC(i)
+      f := f.next
     END;
     RETURN NIL
   END CacheEntry;
@@ -311,19 +299,11 @@ MODULE Files;  (* J. Templ 1.12. 89/12.4.95 Oberon files mapped onto Unix files 
       END;
       LOOP
         error := Platform.OldRW(path, fd); done := error = 0;
-        IF (~done & Platform.TooManyFiles(error)) OR (done & (fd >= fileTabSize)) THEN
-          IF done & (fd >= fileTabSize) THEN error := Platform.Close(fd) END;
-          Heap.GC(TRUE);
-          error := Platform.OldRW(path, fd); done := error = 0;
-          IF ~done & Platform.TooManyFiles(error) THEN
-            (* Console.String("fd = "); Console.Int(fd,1); Console.Ln; *)
-            Err("too many files open", f, error)
-          END
-        END;
+        IF ~done & Platform.TooManyFiles(error) THEN Err("too many files open", f, error) END;
         IF ~done & Platform.Inaccessible(error) THEN
           error := Platform.OldRO(path, fd); done := error = 0;
         END;
-        IF (~done) & (~Platform.Absent(error)) THEN
+        IF ~done & ~Platform.Absent(error) THEN
           Console.String("Warning: Files.Old "); Console.String(name);
           Console.String(" error = "); Console.Int(error, 0); Console.Ln;
         END;
@@ -331,16 +311,15 @@ MODULE Files;  (* J. Templ 1.12. 89/12.4.95 Oberon files mapped onto Unix files 
           (* Console.String("  fd = "); Console.Int(fd,1); Console.Ln; *)
           error := Platform.Identify(fd, identity);
           f := CacheEntry(identity);
-          IF f # NIL THEN error := Platform.Close(fd); RETURN f
-          ELSIF fd >= fileTabSize THEN
-            (* Console.String("fd = "); Console.Int(fd,1); Console.Ln; *)
-            error := Platform.Close(fd);
-            Err("too many files open", f, 0)
-          ELSE NEW(f); fileTab[fd] := SYSTEM.VAL(LONGINT, f); INC(Heap.FileCount); Heap.RegisterFinalizer(f, Finalize);
+          IF f # NIL THEN
+            (* error := Platform.Close(fd); DCWB: Either this should be removed or should call CloseOSFile. *)
+            RETURN f
+          ELSE NEW(f); Heap.RegisterFinalizer(f, Finalize);
             f.fd := fd; f.state := open; f.pos := 0; f.swapper := -1; (*all f.buf[i] = NIL*)
             error := Platform.Size(fd, f.len);
             COPY(name, f.workName); f.registerName := ""; f.tempFile := FALSE;
             f.identity := identity;
+            f.next := files;  files := f; INC(Heap.FileCount);
             RETURN f
           END
         ELSIF dir = "" THEN RETURN NIL
@@ -743,7 +722,7 @@ Especially Length would become fairly complex.
     Console.String(", f.workName = "); Console.String(f.workName); Console.Ln;
     *)
     IF f.fd >= 0 THEN
-      fileTab[f.fd] := 0; res := Platform.Close(f.fd); f.fd := -1; DEC(Heap.FileCount);
+      CloseOSFile(f);
       IF f.tempFile THEN res := Platform.Unlink(f.workName) END
     END
   END Finalize;
@@ -758,15 +737,9 @@ Especially Length would become fairly complex.
     END
   END SetSearchPath;
 
-  PROCEDURE Init;
-    VAR i: LONGINT;
-  BEGIN
-    i := 0; WHILE i < fileTabSize DO fileTab[i] := 0; INC(i) END;
-    tempno := -1;
-    Heap.FileCount := 0;
-    SearchPath := NIL;
-    HOME := "";  Platform.GetEnv("HOME", HOME);
-  END Init;
 
-BEGIN Init
+BEGIN
+  tempno := -1;
+  Heap.FileCount := 0;
+  HOME := "";  Platform.GetEnv("HOME", HOME);
 END Files.

--- a/src/tools/make/buildall.pl
+++ b/src/tools/make/buildall.pl
@@ -6,6 +6,8 @@ use Cwd;
 
 my $branch = "master";
 
+if (defined($ARGV[0]) && ($ARGV[0] ne "")) {$branch = $ARGV[0]}
+
 my %machines = (
   "pi"      => ['pi@pie',          "sudo", "projects/oberon/vishap/voc", "make full"],
   "darwin"  => ['dave@dcb',        "sudo", "projects/oberon/vishap/voc", "make full"],

--- a/src/tools/make/postpush.pl
+++ b/src/tools/make/postpush.pl
@@ -43,7 +43,7 @@ if ($buildneeded) {
   } else {
     close(STDIN); close(STDOUT); close(STDERR);  # child process
     system 'echo Syncing voc>postpush.log';
-    system '(cd voc && git pull) >>postpush.log';
+    system '(cd voc && git pull && git checkout $branch) >>postpush.log';
     exec 'perl voc/src/tools/make/buildall.pl $branch >/tmp/buildall.log';
     exit;
   }

--- a/src/tools/make/postpush.pl
+++ b/src/tools/make/postpush.pl
@@ -43,7 +43,7 @@ if ($buildneeded) {
   } else {
     close(STDIN); close(STDOUT); close(STDERR);  # child process
     system 'echo Syncing voc>postpush.log';
-    system '(cd voc && git pull && git checkout $branch) >>postpush.log';
+    system '(cd voc; git pull; git checkout ' . $branch . ') >>postpush.log';
     exec 'perl voc/src/tools/make/buildall.pl $branch >/tmp/buildall.log';
     exit;
   }

--- a/src/tools/make/postpush.pl
+++ b/src/tools/make/postpush.pl
@@ -44,7 +44,7 @@ if ($buildneeded) {
     close(STDIN); close(STDOUT); close(STDERR);  # child process
     system 'echo Syncing voc>postpush.log';
     system '(cd voc; git pull; git checkout ' . $branch . ') >>postpush.log';
-    exec 'perl voc/src/tools/make/buildall.pl $branch >/tmp/buildall.log';
+    exec 'perl voc/src/tools/make/buildall.pl ' . $branch . ' >/tmp/buildall.log';
     exit;
   }
 } else {

--- a/src/tools/make/postpush.pl
+++ b/src/tools/make/postpush.pl
@@ -36,7 +36,6 @@ for my $file (@{$modified}) {
 if ($buildneeded) {
   writelog "Post push github web hook for repository $repo, branch $branch, name $name. Build required.";
 
-
   my $child = fork;
   if (not defined $child) {die "Fork failed.";}
   if ($child) {
@@ -45,7 +44,7 @@ if ($buildneeded) {
     close(STDIN); close(STDOUT); close(STDERR);  # child process
     system 'echo Syncing voc>postpush.log';
     system '(cd voc && git pull) >>postpush.log';
-    exec 'perl voc/src/tools/make/buildall.pl >/tmp/buildall.log';
+    exec 'perl voc/src/tools/make/buildall.pl $branch >/tmp/buildall.log';
     exit;
   }
 } else {


### PR DESCRIPTION
Files.Mod was recording files with OS handles in a table indexed by handle value. It was lucky that most often on Unix based systems handles did have a small value. However the Files.Mod code included extra compilcation to close and reopen files if the handle it received was numerically larger than the file table.
This change repaces the file table with a singly linked file list, removed the retry code, and turns out to be simpler in general.