### PR TITLE
ReadString [and ReadLine] from Files module are now more Oakwood-friendly

### DIFF
--- a/src/system/Files.Mod
+++ b/src/system/Files.Mod
@@ -636,7 +636,8 @@ Especially Length would become fairly complex.
   PROCEDURE ReadString* (VAR R: Rider; VAR x: ARRAY OF CHAR);
     VAR i: INTEGER; ch: CHAR;
   BEGIN i := 0;
-    REPEAT Read(R, ch); x[i] := ch; INC(i) UNTIL ch = 0X
+    REPEAT Read(R, ch); x[i] := ch; INC(i) UNTIL ch = 0X;
+    x[i] := 0X;
   END ReadString;
 
   PROCEDURE ReadLine* (VAR R: Rider; VAR x: ARRAY OF CHAR);
@@ -652,7 +653,8 @@ Especially Length would become fairly complex.
         x[i] := ch;
         INC(i);
       END;
-    UNTIL b
+    UNTIL b;
+    x[i] := 0X;
   END ReadLine;
 
   PROCEDURE ReadNum* (VAR R: Rider; VAR x: LONGINT);

--- a/src/system/Files.Mod
+++ b/src/system/Files.Mod
@@ -642,14 +642,19 @@ Especially Length would become fairly complex.
   END ReadString;
 
   PROCEDURE ReadLine* (VAR R: Rider; VAR x: ARRAY OF CHAR);
-    VAR i: INTEGER; ch: CHAR; b : BOOLEAN; pos: LONGINT;
+    VAR i: INTEGER; ch: CHAR; b : BOOLEAN; pos: LONGINT; tail: INTEGER;
   BEGIN
     i := 0;
     b := FALSE;
-    pos := Pos(R);
+    pos  := Pos(R);
+    tail := 0;
     REPEAT
       Read(R, ch);
       IF ((ch = 0X) OR (ch = 0AX) OR (ch = 0DX)) THEN
+        IF (ch = 0X) THEN
+          tail := 1;
+        ELSE
+          tail := Strings.Length(Platform.nl);
         b := TRUE
       ELSE
         x[i] := ch;
@@ -657,7 +662,7 @@ Especially Length would become fairly complex.
       END;
     UNTIL b;
     x[i] := 0X;
-    IF ~R.eof THEN Set(R, R.buf.f, pos + i + 1); END;
+    IF ~R.eof THEN Set(R, R.buf.f, pos + i + tail); END;
   END ReadLine;
 
   PROCEDURE ReadNum* (VAR R: Rider; VAR x: LONGINT);

--- a/src/system/Files.Mod
+++ b/src/system/Files.Mod
@@ -634,17 +634,19 @@ Especially Length would become fairly complex.
   END ReadLReal;
 
   PROCEDURE ReadString* (VAR R: Rider; VAR x: ARRAY OF CHAR);
-    VAR i: INTEGER; ch: CHAR;
-  BEGIN i := 0;
+    VAR i: INTEGER; ch: CHAR; pos: LONGINT;
+  BEGIN i := 0; pos := Pos(R);
     REPEAT Read(R, ch); x[i] := ch; INC(i) UNTIL ch = 0X;
     x[i] := 0X;
+    IF ~R.eof THEN Set(R, R.buf.f, pos + i + 1); END;
   END ReadString;
 
   PROCEDURE ReadLine* (VAR R: Rider; VAR x: ARRAY OF CHAR);
-    VAR i: INTEGER; ch: CHAR; b : BOOLEAN;
+    VAR i: INTEGER; ch: CHAR; b : BOOLEAN; pos: LONGINT;
   BEGIN
     i := 0;
     b := FALSE;
+    pos := Pos(R);
     REPEAT
       Read(R, ch);
       IF ((ch = 0X) OR (ch = 0AX) OR (ch = 0DX)) THEN
@@ -655,6 +657,7 @@ Especially Length would become fairly complex.
       END;
     UNTIL b;
     x[i] := 0X;
+    IF ~R.eof THEN Set(R, R.buf.f, pos + i + 1); END;
   END ReadLine;
 
   PROCEDURE ReadNum* (VAR R: Rider; VAR x: LONGINT);

--- a/src/system/Files.Mod
+++ b/src/system/Files.Mod
@@ -655,6 +655,7 @@ Especially Length would become fairly complex.
           tail := 1;
         ELSE
           tail := Strings.Length(Platform.nl);
+        END;
         b := TRUE
       ELSE
         x[i] := ch;


### PR DESCRIPTION
There is a small change to ReadString and ReadLine procedures from Files module to make them put the trailing 0X character into the string being read and adjust the Rider position, as it is recommended in Oakwood Guidelines.

Personally, I don't know if this is a good change that will not break something, so please excuse me, if I am wrong.