### PR TITLE
Introducing SYSTEM.MAXPATHLEN and SYSTEM.MAXFILENAMELEN

### DIFF
--- a/src/compiler/OPT.Mod
+++ b/src/compiler/OPT.Mod
@@ -1315,7 +1315,7 @@ END Import;
   BEGIN
     Insert(name, obj); obj^.conval := NewConst();
     obj^.mode := Con; obj^.typ := int32typ; obj^.conval^.intval := value;
-  END EntarIntConst;
+  END EnterIntConst;
 
   PROCEDURE EnterTyp(name: OPS.Name; form: SHORTINT; size: INTEGER; VAR res: Struct);
     VAR obj: Object; typ: Struct;
@@ -1375,8 +1375,8 @@ BEGIN topScope := NIL; OpenScope(0, NIL); OPM.errpos := 0;
   EnterProc("MOVE",   movefn);
 
   (* POSIX systems normally support PATH_MAX *)
-  EnterIntConst("MAXPATHLEN", Configuration.MaxPathLen);
-  EnterIntConst("MAXFILENAMELENGTH", Configuration.MaxFnLen);
+  EnterIntConst("MAXPATHLEN", Configuration.MaxPathLen);        (*PATH_MAX - 1*)
+  EnterIntConst("MAXFILENAMELEN", Configuration.MaxFnLen);      (*NAME_LEN*)
 
   syslink  := topScope^.right;
   universe := topScope; topScope^.right := NIL;

--- a/src/compiler/OPT.Mod
+++ b/src/compiler/OPT.Mod
@@ -4,7 +4,7 @@ MODULE OPT;  (* NW, RC 6.3.89 / 23.1.92 *)  (* object model 24.2.94 *)
 2002-08-20 jt: NewStr: txtpos remains 0 for structs read from symbol file
 *)
 
-IMPORT OPS, OPM, SYSTEM;
+IMPORT OPS, OPM, SYSTEM, Configuration;
 
 
 (* Constants - value of literals *)
@@ -1310,6 +1310,13 @@ END Import;
     obj^.mode := Con; obj^.typ := booltyp; obj^.conval^.intval := value
   END EnterBoolConst;
 
+  PROCEDURE EnterIntConst(name: OPS.Name; value: LONGINT);
+    VAR obj: Object;
+  BEGIN
+    Insert(name, obj); obj^.conval := NewConst();
+    obj^.mode := Con; obj^.typ := int32typ; obj^.conval^.intval := value;
+  END EntarIntConst;
+
   PROCEDURE EnterTyp(name: OPS.Name; form: SHORTINT; size: INTEGER; VAR res: Struct);
     VAR obj: Object; typ: Struct;
   BEGIN
@@ -1367,6 +1374,9 @@ BEGIN topScope := NIL; OpenScope(0, NIL); OPM.errpos := 0;
   EnterProc("NEW",    sysnewfn);
   EnterProc("MOVE",   movefn);
 
+  (* POSIX systems normally support PATH_MAX *)
+  EnterIntConst("MAXPATHLEN", Configuration.MaxPathLen);
+  EnterIntConst("MAXFILENAMELENGTH", Configuration.MaxFnLen);
 
   syslink  := topScope^.right;
   universe := topScope; topScope^.right := NIL;

--- a/src/tools/make/configure.c
+++ b/src/tools/make/configure.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <time.h>
 #include <string.h>
+#include <limits.h>	// for enabling PATH_MAX ...
 
 
 void fail(char *msg) {fprintf(stderr, "Error: %s\n", msg); exit(1);}
@@ -42,8 +43,8 @@ char builddate[256];
 char installdir[256];
 char versionstring[256];
 char osrelease[1024];
-char cwd[1024];
-char libspec[1024];
+char cwd[PATH_MAX];
+char libspec[PATH_MAX*8];
 
 #define macrotostringhelper(s) #s
 #define macrotostring(s) macrotostringhelper(s)
@@ -401,6 +402,8 @@ void writeConfigurationMod() {
   fprintf(fd, "  compile*     = '%s';\n", cc);
   fprintf(fd, "  installdir*  = '%s';\n", installdir);
   fprintf(fd, "  staticLink*  = '%s';\n", staticlink);
+  fprintf(fd, "  MaxPathLen*  = %d;\n", PATH_MAX);
+  fprintf(fd  "  MaxFnLen*    = %d;\n", NAME_MAX);
   fprintf(fd, "VAR\n");
   fprintf(fd, "  versionLong-: ARRAY %d OF CHAR;\n", (int)strnlen(versionstring, 100)+1);
   fprintf(fd, "BEGIN\n");

--- a/src/tools/make/configure.c
+++ b/src/tools/make/configure.c
@@ -402,8 +402,8 @@ void writeConfigurationMod() {
   fprintf(fd, "  compile*     = '%s';\n", cc);
   fprintf(fd, "  installdir*  = '%s';\n", installdir);
   fprintf(fd, "  staticLink*  = '%s';\n", staticlink);
-  fprintf(fd, "  MaxPathLen*  = %d;\n", PATH_MAX);
-  fprintf(fd  "  MaxFnLen*    = %d;\n", NAME_MAX);
+  fprintf(fd, "  MaxPathLen*  = %d;\n", PATH_MAX-1); // -1 for more consistency
+  fprintf(fd, "  MaxFnLen*    = %d;\n", NAME_MAX);
   fprintf(fd, "VAR\n");
   fprintf(fd, "  versionLong-: ARRAY %d OF CHAR;\n", (int)strnlen(versionstring, 100)+1);
   fprintf(fd, "BEGIN\n");


### PR DESCRIPTION
Hi!

This is my first pull request ... so, sorry if my explanations are somewhat long.

I modified 'src/tools/make/configure.c' in a way that it inserts 'PATH_MAX' and 'NAME_MAX' (as exported constants 'MaxPathLen' and 'MaxFnLen' into 'Configuration.Mod', thus allowing the system's limits for pathnames to be used.
In the next step, i modified 'src/compiler/OPT.Mod' - importing 'Configuration', implementing 'EnterIntConst()' (using 'EnterBoolConst()' as a prototype) and adding the two new constants MAXPATHLEN ('Configuration.MaxPathLen') and MAXFILENAMELEN ('Configuration.MaxFnLen') to the pseudo-module SYSTEM.

This allows for using the limits for path- and filenames of the system the compiler was generated on. Somewhat tricky, i know, but this should solve some of the problems with too short pathname-buffers.

If this modification is accepted, i will make modifications on 'src/runtime/Files.Mod', removing (most of) the buffer overflow problems i found in this file. (Fact is, already made these modifications, but i couldn't test the module yet ...)