### PR TITLE
Undecl var fix

### DIFF
--- a/bootstrap/unix-44/Compiler.c
+++ b/bootstrap/unix-44/Compiler.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/Configuration.c
+++ b/bootstrap/unix-44/Configuration.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -19,6 +19,6 @@ export void *Configuration__init(void)
 	__DEFMOD;
 	__REGMOD("Configuration", 0);
 /* BEGIN */
-	__MOVE("2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
+	__MOVE("2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
 	__ENDMOD;
 }

--- a/bootstrap/unix-44/Configuration.h
+++ b/bootstrap/unix-44/Configuration.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Configuration__h
 #define Configuration__h

--- a/bootstrap/unix-44/Files.c
+++ b/bootstrap/unix-44/Files.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/Files.h
+++ b/bootstrap/unix-44/Files.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Files__h
 #define Files__h

--- a/bootstrap/unix-44/Heap.c
+++ b/bootstrap/unix-44/Heap.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/Heap.h
+++ b/bootstrap/unix-44/Heap.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #ifndef Heap__h
 #define Heap__h

--- a/bootstrap/unix-44/Modules.c
+++ b/bootstrap/unix-44/Modules.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/Modules.h
+++ b/bootstrap/unix-44/Modules.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Modules__h
 #define Modules__h

--- a/bootstrap/unix-44/OPB.c
+++ b/bootstrap/unix-44/OPB.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/OPB.h
+++ b/bootstrap/unix-44/OPB.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPB__h
 #define OPB__h

--- a/bootstrap/unix-44/OPC.c
+++ b/bootstrap/unix-44/OPC.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -1834,6 +1834,12 @@ void OPC_IntLiteral (INT64 n, INT32 size)
 
 void OPC_Len (OPT_Object obj, OPT_Struct array, INT64 dim)
 {
+	INT64 d;
+	d = dim;
+	while (d > 0) {
+		array = array->BaseTyp;
+		d -= 1;
+	}
 	if (array->comp == 3) {
 		OPC_CompleteIdent(obj);
 		OPM_WriteString((CHAR*)"__len", 6);
@@ -1841,10 +1847,6 @@ void OPC_Len (OPT_Object obj, OPT_Struct array, INT64 dim)
 			OPM_WriteInt(dim);
 		}
 	} else {
-		while (dim > 0) {
-			array = array->BaseTyp;
-			dim -= 1;
-		}
 		OPM_WriteInt(array->n);
 	}
 }

--- a/bootstrap/unix-44/OPC.h
+++ b/bootstrap/unix-44/OPC.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPC__h
 #define OPC__h

--- a/bootstrap/unix-44/OPM.c
+++ b/bootstrap/unix-44/OPM.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/OPM.h
+++ b/bootstrap/unix-44/OPM.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPM__h
 #define OPM__h

--- a/bootstrap/unix-44/OPP.c
+++ b/bootstrap/unix-44/OPP.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/OPP.h
+++ b/bootstrap/unix-44/OPP.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPP__h
 #define OPP__h

--- a/bootstrap/unix-44/OPS.c
+++ b/bootstrap/unix-44/OPS.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/OPS.h
+++ b/bootstrap/unix-44/OPS.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPS__h
 #define OPS__h

--- a/bootstrap/unix-44/OPT.c
+++ b/bootstrap/unix-44/OPT.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/OPT.h
+++ b/bootstrap/unix-44/OPT.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPT__h
 #define OPT__h

--- a/bootstrap/unix-44/OPV.c
+++ b/bootstrap/unix-44/OPV.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -317,15 +317,27 @@ static INT16 OPV_Precedence (INT16 class, INT16 subclass, INT16 form, INT16 comp
 
 static void OPV_Len (OPT_Node n, INT64 dim)
 {
+	INT64 d;
+	OPT_Struct array = NIL;
 	while ((n->class == 4 && n->typ->comp == 3)) {
 		dim += 1;
 		n = n->left;
 	}
 	if ((n->class == 3 && n->typ->comp == 3)) {
-		OPV_design(n->left, 10);
-		OPM_WriteString((CHAR*)"->len[", 7);
-		OPM_WriteInt(dim);
-		OPM_Write(']');
+		d = dim;
+		array = n->typ;
+		while (d > 0) {
+			array = array->BaseTyp;
+			d -= 1;
+		}
+		if (array->comp == 3) {
+			OPV_design(n->left, 10);
+			OPM_WriteString((CHAR*)"->len[", 7);
+			OPM_WriteInt(dim);
+			OPM_Write(']');
+		} else {
+			OPM_WriteInt(array->n);
+		}
 	} else {
 		OPC_Len(n->obj, n->typ, dim);
 	}

--- a/bootstrap/unix-44/OPV.h
+++ b/bootstrap/unix-44/OPV.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPV__h
 #define OPV__h

--- a/bootstrap/unix-44/Out.c
+++ b/bootstrap/unix-44/Out.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/Out.h
+++ b/bootstrap/unix-44/Out.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Out__h
 #define Out__h

--- a/bootstrap/unix-44/Platform.c
+++ b/bootstrap/unix-44/Platform.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/Platform.h
+++ b/bootstrap/unix-44/Platform.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Platform__h
 #define Platform__h

--- a/bootstrap/unix-44/Reals.c
+++ b/bootstrap/unix-44/Reals.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/Reals.h
+++ b/bootstrap/unix-44/Reals.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Reals__h
 #define Reals__h

--- a/bootstrap/unix-44/Strings.c
+++ b/bootstrap/unix-44/Strings.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/Strings.h
+++ b/bootstrap/unix-44/Strings.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Strings__h
 #define Strings__h

--- a/bootstrap/unix-44/Texts.c
+++ b/bootstrap/unix-44/Texts.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/Texts.h
+++ b/bootstrap/unix-44/Texts.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Texts__h
 #define Texts__h

--- a/bootstrap/unix-44/VT100.c
+++ b/bootstrap/unix-44/VT100.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/VT100.h
+++ b/bootstrap/unix-44/VT100.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef VT100__h
 #define VT100__h

--- a/bootstrap/unix-44/extTools.c
+++ b/bootstrap/unix-44/extTools.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -72,7 +72,7 @@ static void extTools_execute (CHAR *title, ADDRESS title__len, CHAR *cmd, ADDRES
 
 static void extTools_InitialiseCompilerCommand (CHAR *s, ADDRESS s__len)
 {
-	__COPY("tcc -g", s, s__len);
+	__COPY("gcc -fPIC -g", s, s__len);
 	Strings_Append((CHAR*)" -I \"", 6, (void*)s, s__len);
 	Strings_Append(OPM_ResourceDir, 1024, (void*)s, s__len);
 	Strings_Append((CHAR*)"/include\" ", 11, (void*)s, s__len);
@@ -102,7 +102,7 @@ void extTools_LinkMain (CHAR *moduleName, ADDRESS moduleName__len, BOOLEAN stati
 	Strings_Append((CHAR*)".c ", 4, (void*)cmd, 4096);
 	Strings_Append(additionalopts, additionalopts__len, (void*)cmd, 4096);
 	if (statically) {
-		Strings_Append((CHAR*)"", 1, (void*)cmd, 4096);
+		Strings_Append((CHAR*)" -static", 9, (void*)cmd, 4096);
 	}
 	Strings_Append((CHAR*)" -o ", 5, (void*)cmd, 4096);
 	Strings_Append(moduleName, moduleName__len, (void*)cmd, 4096);

--- a/bootstrap/unix-44/extTools.h
+++ b/bootstrap/unix-44/extTools.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef extTools__h
 #define extTools__h

--- a/bootstrap/unix-48/Compiler.c
+++ b/bootstrap/unix-48/Compiler.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/Configuration.c
+++ b/bootstrap/unix-48/Configuration.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -19,6 +19,6 @@ export void *Configuration__init(void)
 	__DEFMOD;
 	__REGMOD("Configuration", 0);
 /* BEGIN */
-	__MOVE("2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
+	__MOVE("2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
 	__ENDMOD;
 }

--- a/bootstrap/unix-48/Configuration.h
+++ b/bootstrap/unix-48/Configuration.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Configuration__h
 #define Configuration__h

--- a/bootstrap/unix-48/Files.c
+++ b/bootstrap/unix-48/Files.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/Files.h
+++ b/bootstrap/unix-48/Files.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Files__h
 #define Files__h

--- a/bootstrap/unix-48/Heap.c
+++ b/bootstrap/unix-48/Heap.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/Heap.h
+++ b/bootstrap/unix-48/Heap.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #ifndef Heap__h
 #define Heap__h

--- a/bootstrap/unix-48/Modules.c
+++ b/bootstrap/unix-48/Modules.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/Modules.h
+++ b/bootstrap/unix-48/Modules.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Modules__h
 #define Modules__h

--- a/bootstrap/unix-48/OPB.c
+++ b/bootstrap/unix-48/OPB.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/OPB.h
+++ b/bootstrap/unix-48/OPB.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPB__h
 #define OPB__h

--- a/bootstrap/unix-48/OPC.c
+++ b/bootstrap/unix-48/OPC.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -1834,6 +1834,12 @@ void OPC_IntLiteral (INT64 n, INT32 size)
 
 void OPC_Len (OPT_Object obj, OPT_Struct array, INT64 dim)
 {
+	INT64 d;
+	d = dim;
+	while (d > 0) {
+		array = array->BaseTyp;
+		d -= 1;
+	}
 	if (array->comp == 3) {
 		OPC_CompleteIdent(obj);
 		OPM_WriteString((CHAR*)"__len", 6);
@@ -1841,10 +1847,6 @@ void OPC_Len (OPT_Object obj, OPT_Struct array, INT64 dim)
 			OPM_WriteInt(dim);
 		}
 	} else {
-		while (dim > 0) {
-			array = array->BaseTyp;
-			dim -= 1;
-		}
 		OPM_WriteInt(array->n);
 	}
 }

--- a/bootstrap/unix-48/OPC.h
+++ b/bootstrap/unix-48/OPC.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPC__h
 #define OPC__h

--- a/bootstrap/unix-48/OPM.c
+++ b/bootstrap/unix-48/OPM.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/OPM.h
+++ b/bootstrap/unix-48/OPM.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPM__h
 #define OPM__h

--- a/bootstrap/unix-48/OPP.c
+++ b/bootstrap/unix-48/OPP.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/OPP.h
+++ b/bootstrap/unix-48/OPP.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPP__h
 #define OPP__h

--- a/bootstrap/unix-48/OPS.c
+++ b/bootstrap/unix-48/OPS.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/OPS.h
+++ b/bootstrap/unix-48/OPS.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPS__h
 #define OPS__h

--- a/bootstrap/unix-48/OPT.c
+++ b/bootstrap/unix-48/OPT.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/OPT.h
+++ b/bootstrap/unix-48/OPT.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPT__h
 #define OPT__h

--- a/bootstrap/unix-48/OPV.c
+++ b/bootstrap/unix-48/OPV.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -317,15 +317,27 @@ static INT16 OPV_Precedence (INT16 class, INT16 subclass, INT16 form, INT16 comp
 
 static void OPV_Len (OPT_Node n, INT64 dim)
 {
+	INT64 d;
+	OPT_Struct array = NIL;
 	while ((n->class == 4 && n->typ->comp == 3)) {
 		dim += 1;
 		n = n->left;
 	}
 	if ((n->class == 3 && n->typ->comp == 3)) {
-		OPV_design(n->left, 10);
-		OPM_WriteString((CHAR*)"->len[", 7);
-		OPM_WriteInt(dim);
-		OPM_Write(']');
+		d = dim;
+		array = n->typ;
+		while (d > 0) {
+			array = array->BaseTyp;
+			d -= 1;
+		}
+		if (array->comp == 3) {
+			OPV_design(n->left, 10);
+			OPM_WriteString((CHAR*)"->len[", 7);
+			OPM_WriteInt(dim);
+			OPM_Write(']');
+		} else {
+			OPM_WriteInt(array->n);
+		}
 	} else {
 		OPC_Len(n->obj, n->typ, dim);
 	}

--- a/bootstrap/unix-48/OPV.h
+++ b/bootstrap/unix-48/OPV.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPV__h
 #define OPV__h

--- a/bootstrap/unix-48/Out.c
+++ b/bootstrap/unix-48/Out.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/Out.h
+++ b/bootstrap/unix-48/Out.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Out__h
 #define Out__h

--- a/bootstrap/unix-48/Platform.c
+++ b/bootstrap/unix-48/Platform.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/Platform.h
+++ b/bootstrap/unix-48/Platform.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Platform__h
 #define Platform__h

--- a/bootstrap/unix-48/Reals.c
+++ b/bootstrap/unix-48/Reals.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/Reals.h
+++ b/bootstrap/unix-48/Reals.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Reals__h
 #define Reals__h

--- a/bootstrap/unix-48/Strings.c
+++ b/bootstrap/unix-48/Strings.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/Strings.h
+++ b/bootstrap/unix-48/Strings.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Strings__h
 #define Strings__h

--- a/bootstrap/unix-48/Texts.c
+++ b/bootstrap/unix-48/Texts.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/Texts.h
+++ b/bootstrap/unix-48/Texts.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Texts__h
 #define Texts__h

--- a/bootstrap/unix-48/VT100.c
+++ b/bootstrap/unix-48/VT100.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/VT100.h
+++ b/bootstrap/unix-48/VT100.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef VT100__h
 #define VT100__h

--- a/bootstrap/unix-48/extTools.c
+++ b/bootstrap/unix-48/extTools.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -72,7 +72,7 @@ static void extTools_execute (CHAR *title, ADDRESS title__len, CHAR *cmd, ADDRES
 
 static void extTools_InitialiseCompilerCommand (CHAR *s, ADDRESS s__len)
 {
-	__COPY("tcc -g", s, s__len);
+	__COPY("gcc -fPIC -g", s, s__len);
 	Strings_Append((CHAR*)" -I \"", 6, (void*)s, s__len);
 	Strings_Append(OPM_ResourceDir, 1024, (void*)s, s__len);
 	Strings_Append((CHAR*)"/include\" ", 11, (void*)s, s__len);
@@ -102,7 +102,7 @@ void extTools_LinkMain (CHAR *moduleName, ADDRESS moduleName__len, BOOLEAN stati
 	Strings_Append((CHAR*)".c ", 4, (void*)cmd, 4096);
 	Strings_Append(additionalopts, additionalopts__len, (void*)cmd, 4096);
 	if (statically) {
-		Strings_Append((CHAR*)"", 1, (void*)cmd, 4096);
+		Strings_Append((CHAR*)" -static", 9, (void*)cmd, 4096);
 	}
 	Strings_Append((CHAR*)" -o ", 5, (void*)cmd, 4096);
 	Strings_Append(moduleName, moduleName__len, (void*)cmd, 4096);

--- a/bootstrap/unix-48/extTools.h
+++ b/bootstrap/unix-48/extTools.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef extTools__h
 #define extTools__h

--- a/bootstrap/unix-88/Compiler.c
+++ b/bootstrap/unix-88/Compiler.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/Configuration.c
+++ b/bootstrap/unix-88/Configuration.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -19,6 +19,6 @@ export void *Configuration__init(void)
 	__DEFMOD;
 	__REGMOD("Configuration", 0);
 /* BEGIN */
-	__MOVE("2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
+	__MOVE("2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
 	__ENDMOD;
 }

--- a/bootstrap/unix-88/Configuration.h
+++ b/bootstrap/unix-88/Configuration.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Configuration__h
 #define Configuration__h

--- a/bootstrap/unix-88/Files.c
+++ b/bootstrap/unix-88/Files.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/Files.h
+++ b/bootstrap/unix-88/Files.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Files__h
 #define Files__h

--- a/bootstrap/unix-88/Heap.c
+++ b/bootstrap/unix-88/Heap.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/Heap.h
+++ b/bootstrap/unix-88/Heap.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #ifndef Heap__h
 #define Heap__h

--- a/bootstrap/unix-88/Modules.c
+++ b/bootstrap/unix-88/Modules.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/Modules.h
+++ b/bootstrap/unix-88/Modules.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Modules__h
 #define Modules__h

--- a/bootstrap/unix-88/OPB.c
+++ b/bootstrap/unix-88/OPB.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/OPB.h
+++ b/bootstrap/unix-88/OPB.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPB__h
 #define OPB__h

--- a/bootstrap/unix-88/OPC.c
+++ b/bootstrap/unix-88/OPC.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -1834,6 +1834,12 @@ void OPC_IntLiteral (INT64 n, INT32 size)
 
 void OPC_Len (OPT_Object obj, OPT_Struct array, INT64 dim)
 {
+	INT64 d;
+	d = dim;
+	while (d > 0) {
+		array = array->BaseTyp;
+		d -= 1;
+	}
 	if (array->comp == 3) {
 		OPC_CompleteIdent(obj);
 		OPM_WriteString((CHAR*)"__len", 6);
@@ -1841,10 +1847,6 @@ void OPC_Len (OPT_Object obj, OPT_Struct array, INT64 dim)
 			OPM_WriteInt(dim);
 		}
 	} else {
-		while (dim > 0) {
-			array = array->BaseTyp;
-			dim -= 1;
-		}
 		OPM_WriteInt(array->n);
 	}
 }

--- a/bootstrap/unix-88/OPC.h
+++ b/bootstrap/unix-88/OPC.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPC__h
 #define OPC__h

--- a/bootstrap/unix-88/OPM.c
+++ b/bootstrap/unix-88/OPM.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/OPM.h
+++ b/bootstrap/unix-88/OPM.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPM__h
 #define OPM__h

--- a/bootstrap/unix-88/OPP.c
+++ b/bootstrap/unix-88/OPP.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/OPP.h
+++ b/bootstrap/unix-88/OPP.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPP__h
 #define OPP__h

--- a/bootstrap/unix-88/OPS.c
+++ b/bootstrap/unix-88/OPS.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/OPS.h
+++ b/bootstrap/unix-88/OPS.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPS__h
 #define OPS__h

--- a/bootstrap/unix-88/OPT.c
+++ b/bootstrap/unix-88/OPT.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/OPT.h
+++ b/bootstrap/unix-88/OPT.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPT__h
 #define OPT__h

--- a/bootstrap/unix-88/OPV.c
+++ b/bootstrap/unix-88/OPV.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -317,15 +317,27 @@ static INT16 OPV_Precedence (INT16 class, INT16 subclass, INT16 form, INT16 comp
 
 static void OPV_Len (OPT_Node n, INT64 dim)
 {
+	INT64 d;
+	OPT_Struct array = NIL;
 	while ((n->class == 4 && n->typ->comp == 3)) {
 		dim += 1;
 		n = n->left;
 	}
 	if ((n->class == 3 && n->typ->comp == 3)) {
-		OPV_design(n->left, 10);
-		OPM_WriteString((CHAR*)"->len[", 7);
-		OPM_WriteInt(dim);
-		OPM_Write(']');
+		d = dim;
+		array = n->typ;
+		while (d > 0) {
+			array = array->BaseTyp;
+			d -= 1;
+		}
+		if (array->comp == 3) {
+			OPV_design(n->left, 10);
+			OPM_WriteString((CHAR*)"->len[", 7);
+			OPM_WriteInt(dim);
+			OPM_Write(']');
+		} else {
+			OPM_WriteInt(array->n);
+		}
 	} else {
 		OPC_Len(n->obj, n->typ, dim);
 	}

--- a/bootstrap/unix-88/OPV.h
+++ b/bootstrap/unix-88/OPV.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPV__h
 #define OPV__h

--- a/bootstrap/unix-88/Out.c
+++ b/bootstrap/unix-88/Out.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/Out.h
+++ b/bootstrap/unix-88/Out.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Out__h
 #define Out__h

--- a/bootstrap/unix-88/Platform.c
+++ b/bootstrap/unix-88/Platform.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/Platform.h
+++ b/bootstrap/unix-88/Platform.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Platform__h
 #define Platform__h

--- a/bootstrap/unix-88/Reals.c
+++ b/bootstrap/unix-88/Reals.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/Reals.h
+++ b/bootstrap/unix-88/Reals.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Reals__h
 #define Reals__h

--- a/bootstrap/unix-88/Strings.c
+++ b/bootstrap/unix-88/Strings.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/Strings.h
+++ b/bootstrap/unix-88/Strings.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Strings__h
 #define Strings__h

--- a/bootstrap/unix-88/Texts.c
+++ b/bootstrap/unix-88/Texts.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/Texts.h
+++ b/bootstrap/unix-88/Texts.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Texts__h
 #define Texts__h

--- a/bootstrap/unix-88/VT100.c
+++ b/bootstrap/unix-88/VT100.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/VT100.h
+++ b/bootstrap/unix-88/VT100.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef VT100__h
 #define VT100__h

--- a/bootstrap/unix-88/extTools.c
+++ b/bootstrap/unix-88/extTools.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -72,7 +72,7 @@ static void extTools_execute (CHAR *title, ADDRESS title__len, CHAR *cmd, ADDRES
 
 static void extTools_InitialiseCompilerCommand (CHAR *s, ADDRESS s__len)
 {
-	__COPY("tcc -g", s, s__len);
+	__COPY("gcc -fPIC -g", s, s__len);
 	Strings_Append((CHAR*)" -I \"", 6, (void*)s, s__len);
 	Strings_Append(OPM_ResourceDir, 1024, (void*)s, s__len);
 	Strings_Append((CHAR*)"/include\" ", 11, (void*)s, s__len);
@@ -102,7 +102,7 @@ void extTools_LinkMain (CHAR *moduleName, ADDRESS moduleName__len, BOOLEAN stati
 	Strings_Append((CHAR*)".c ", 4, (void*)cmd, 4096);
 	Strings_Append(additionalopts, additionalopts__len, (void*)cmd, 4096);
 	if (statically) {
-		Strings_Append((CHAR*)"", 1, (void*)cmd, 4096);
+		Strings_Append((CHAR*)" -static", 9, (void*)cmd, 4096);
 	}
 	Strings_Append((CHAR*)" -o ", 5, (void*)cmd, 4096);
 	Strings_Append(moduleName, moduleName__len, (void*)cmd, 4096);

--- a/bootstrap/unix-88/extTools.h
+++ b/bootstrap/unix-88/extTools.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef extTools__h
 #define extTools__h

--- a/bootstrap/windows-48/Compiler.c
+++ b/bootstrap/windows-48/Compiler.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/Configuration.c
+++ b/bootstrap/windows-48/Configuration.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -19,6 +19,6 @@ export void *Configuration__init(void)
 	__DEFMOD;
 	__REGMOD("Configuration", 0);
 /* BEGIN */
-	__MOVE("2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
+	__MOVE("2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
 	__ENDMOD;
 }

--- a/bootstrap/windows-48/Configuration.h
+++ b/bootstrap/windows-48/Configuration.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Configuration__h
 #define Configuration__h

--- a/bootstrap/windows-48/Files.c
+++ b/bootstrap/windows-48/Files.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/Files.h
+++ b/bootstrap/windows-48/Files.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Files__h
 #define Files__h

--- a/bootstrap/windows-48/Heap.c
+++ b/bootstrap/windows-48/Heap.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/Heap.h
+++ b/bootstrap/windows-48/Heap.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #ifndef Heap__h
 #define Heap__h

--- a/bootstrap/windows-48/Modules.c
+++ b/bootstrap/windows-48/Modules.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/Modules.h
+++ b/bootstrap/windows-48/Modules.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Modules__h
 #define Modules__h

--- a/bootstrap/windows-48/OPB.c
+++ b/bootstrap/windows-48/OPB.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/OPB.h
+++ b/bootstrap/windows-48/OPB.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPB__h
 #define OPB__h

--- a/bootstrap/windows-48/OPC.c
+++ b/bootstrap/windows-48/OPC.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -1834,6 +1834,12 @@ void OPC_IntLiteral (INT64 n, INT32 size)
 
 void OPC_Len (OPT_Object obj, OPT_Struct array, INT64 dim)
 {
+	INT64 d;
+	d = dim;
+	while (d > 0) {
+		array = array->BaseTyp;
+		d -= 1;
+	}
 	if (array->comp == 3) {
 		OPC_CompleteIdent(obj);
 		OPM_WriteString((CHAR*)"__len", 6);
@@ -1841,10 +1847,6 @@ void OPC_Len (OPT_Object obj, OPT_Struct array, INT64 dim)
 			OPM_WriteInt(dim);
 		}
 	} else {
-		while (dim > 0) {
-			array = array->BaseTyp;
-			dim -= 1;
-		}
 		OPM_WriteInt(array->n);
 	}
 }

--- a/bootstrap/windows-48/OPC.h
+++ b/bootstrap/windows-48/OPC.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPC__h
 #define OPC__h

--- a/bootstrap/windows-48/OPM.c
+++ b/bootstrap/windows-48/OPM.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/OPM.h
+++ b/bootstrap/windows-48/OPM.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPM__h
 #define OPM__h

--- a/bootstrap/windows-48/OPP.c
+++ b/bootstrap/windows-48/OPP.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/OPP.h
+++ b/bootstrap/windows-48/OPP.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPP__h
 #define OPP__h

--- a/bootstrap/windows-48/OPS.c
+++ b/bootstrap/windows-48/OPS.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/OPS.h
+++ b/bootstrap/windows-48/OPS.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPS__h
 #define OPS__h

--- a/bootstrap/windows-48/OPT.c
+++ b/bootstrap/windows-48/OPT.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/OPT.h
+++ b/bootstrap/windows-48/OPT.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPT__h
 #define OPT__h

--- a/bootstrap/windows-48/OPV.c
+++ b/bootstrap/windows-48/OPV.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -317,15 +317,27 @@ static INT16 OPV_Precedence (INT16 class, INT16 subclass, INT16 form, INT16 comp
 
 static void OPV_Len (OPT_Node n, INT64 dim)
 {
+	INT64 d;
+	OPT_Struct array = NIL;
 	while ((n->class == 4 && n->typ->comp == 3)) {
 		dim += 1;
 		n = n->left;
 	}
 	if ((n->class == 3 && n->typ->comp == 3)) {
-		OPV_design(n->left, 10);
-		OPM_WriteString((CHAR*)"->len[", 7);
-		OPM_WriteInt(dim);
-		OPM_Write(']');
+		d = dim;
+		array = n->typ;
+		while (d > 0) {
+			array = array->BaseTyp;
+			d -= 1;
+		}
+		if (array->comp == 3) {
+			OPV_design(n->left, 10);
+			OPM_WriteString((CHAR*)"->len[", 7);
+			OPM_WriteInt(dim);
+			OPM_Write(']');
+		} else {
+			OPM_WriteInt(array->n);
+		}
 	} else {
 		OPC_Len(n->obj, n->typ, dim);
 	}

--- a/bootstrap/windows-48/OPV.h
+++ b/bootstrap/windows-48/OPV.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPV__h
 #define OPV__h

--- a/bootstrap/windows-48/Out.c
+++ b/bootstrap/windows-48/Out.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/Out.h
+++ b/bootstrap/windows-48/Out.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Out__h
 #define Out__h

--- a/bootstrap/windows-48/Platform.c
+++ b/bootstrap/windows-48/Platform.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/Platform.h
+++ b/bootstrap/windows-48/Platform.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Platform__h
 #define Platform__h

--- a/bootstrap/windows-48/Reals.c
+++ b/bootstrap/windows-48/Reals.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/Reals.h
+++ b/bootstrap/windows-48/Reals.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Reals__h
 #define Reals__h

--- a/bootstrap/windows-48/Strings.c
+++ b/bootstrap/windows-48/Strings.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/Strings.h
+++ b/bootstrap/windows-48/Strings.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Strings__h
 #define Strings__h

--- a/bootstrap/windows-48/Texts.c
+++ b/bootstrap/windows-48/Texts.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/Texts.h
+++ b/bootstrap/windows-48/Texts.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Texts__h
 #define Texts__h

--- a/bootstrap/windows-48/VT100.c
+++ b/bootstrap/windows-48/VT100.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/VT100.h
+++ b/bootstrap/windows-48/VT100.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef VT100__h
 #define VT100__h

--- a/bootstrap/windows-48/extTools.c
+++ b/bootstrap/windows-48/extTools.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -72,7 +72,7 @@ static void extTools_execute (CHAR *title, ADDRESS title__len, CHAR *cmd, ADDRES
 
 static void extTools_InitialiseCompilerCommand (CHAR *s, ADDRESS s__len)
 {
-	__COPY("tcc -g", s, s__len);
+	__COPY("gcc -fPIC -g", s, s__len);
 	Strings_Append((CHAR*)" -I \"", 6, (void*)s, s__len);
 	Strings_Append(OPM_ResourceDir, 1024, (void*)s, s__len);
 	Strings_Append((CHAR*)"/include\" ", 11, (void*)s, s__len);
@@ -102,7 +102,7 @@ void extTools_LinkMain (CHAR *moduleName, ADDRESS moduleName__len, BOOLEAN stati
 	Strings_Append((CHAR*)".c ", 4, (void*)cmd, 4096);
 	Strings_Append(additionalopts, additionalopts__len, (void*)cmd, 4096);
 	if (statically) {
-		Strings_Append((CHAR*)"", 1, (void*)cmd, 4096);
+		Strings_Append((CHAR*)" -static", 9, (void*)cmd, 4096);
 	}
 	Strings_Append((CHAR*)" -o ", 5, (void*)cmd, 4096);
 	Strings_Append(moduleName, moduleName__len, (void*)cmd, 4096);

--- a/bootstrap/windows-48/extTools.h
+++ b/bootstrap/windows-48/extTools.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef extTools__h
 #define extTools__h

--- a/bootstrap/windows-88/Compiler.c
+++ b/bootstrap/windows-88/Compiler.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/Configuration.c
+++ b/bootstrap/windows-88/Configuration.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -19,6 +19,6 @@ export void *Configuration__init(void)
 	__DEFMOD;
 	__REGMOD("Configuration", 0);
 /* BEGIN */
-	__MOVE("2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
+	__MOVE("2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
 	__ENDMOD;
 }

--- a/bootstrap/windows-88/Configuration.h
+++ b/bootstrap/windows-88/Configuration.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Configuration__h
 #define Configuration__h

--- a/bootstrap/windows-88/Files.c
+++ b/bootstrap/windows-88/Files.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/Files.h
+++ b/bootstrap/windows-88/Files.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Files__h
 #define Files__h

--- a/bootstrap/windows-88/Heap.c
+++ b/bootstrap/windows-88/Heap.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/Heap.h
+++ b/bootstrap/windows-88/Heap.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #ifndef Heap__h
 #define Heap__h

--- a/bootstrap/windows-88/Modules.c
+++ b/bootstrap/windows-88/Modules.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/Modules.h
+++ b/bootstrap/windows-88/Modules.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Modules__h
 #define Modules__h

--- a/bootstrap/windows-88/OPB.c
+++ b/bootstrap/windows-88/OPB.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/OPB.h
+++ b/bootstrap/windows-88/OPB.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPB__h
 #define OPB__h

--- a/bootstrap/windows-88/OPC.c
+++ b/bootstrap/windows-88/OPC.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -1834,6 +1834,12 @@ void OPC_IntLiteral (INT64 n, INT32 size)
 
 void OPC_Len (OPT_Object obj, OPT_Struct array, INT64 dim)
 {
+	INT64 d;
+	d = dim;
+	while (d > 0) {
+		array = array->BaseTyp;
+		d -= 1;
+	}
 	if (array->comp == 3) {
 		OPC_CompleteIdent(obj);
 		OPM_WriteString((CHAR*)"__len", 6);
@@ -1841,10 +1847,6 @@ void OPC_Len (OPT_Object obj, OPT_Struct array, INT64 dim)
 			OPM_WriteInt(dim);
 		}
 	} else {
-		while (dim > 0) {
-			array = array->BaseTyp;
-			dim -= 1;
-		}
 		OPM_WriteInt(array->n);
 	}
 }

--- a/bootstrap/windows-88/OPC.h
+++ b/bootstrap/windows-88/OPC.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPC__h
 #define OPC__h

--- a/bootstrap/windows-88/OPM.c
+++ b/bootstrap/windows-88/OPM.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/OPM.h
+++ b/bootstrap/windows-88/OPM.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPM__h
 #define OPM__h

--- a/bootstrap/windows-88/OPP.c
+++ b/bootstrap/windows-88/OPP.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/OPP.h
+++ b/bootstrap/windows-88/OPP.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPP__h
 #define OPP__h

--- a/bootstrap/windows-88/OPS.c
+++ b/bootstrap/windows-88/OPS.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/OPS.h
+++ b/bootstrap/windows-88/OPS.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPS__h
 #define OPS__h

--- a/bootstrap/windows-88/OPT.c
+++ b/bootstrap/windows-88/OPT.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/OPT.h
+++ b/bootstrap/windows-88/OPT.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPT__h
 #define OPT__h

--- a/bootstrap/windows-88/OPV.c
+++ b/bootstrap/windows-88/OPV.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -317,15 +317,27 @@ static INT16 OPV_Precedence (INT16 class, INT16 subclass, INT16 form, INT16 comp
 
 static void OPV_Len (OPT_Node n, INT64 dim)
 {
+	INT64 d;
+	OPT_Struct array = NIL;
 	while ((n->class == 4 && n->typ->comp == 3)) {
 		dim += 1;
 		n = n->left;
 	}
 	if ((n->class == 3 && n->typ->comp == 3)) {
-		OPV_design(n->left, 10);
-		OPM_WriteString((CHAR*)"->len[", 7);
-		OPM_WriteInt(dim);
-		OPM_Write(']');
+		d = dim;
+		array = n->typ;
+		while (d > 0) {
+			array = array->BaseTyp;
+			d -= 1;
+		}
+		if (array->comp == 3) {
+			OPV_design(n->left, 10);
+			OPM_WriteString((CHAR*)"->len[", 7);
+			OPM_WriteInt(dim);
+			OPM_Write(']');
+		} else {
+			OPM_WriteInt(array->n);
+		}
 	} else {
 		OPC_Len(n->obj, n->typ, dim);
 	}

--- a/bootstrap/windows-88/OPV.h
+++ b/bootstrap/windows-88/OPV.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPV__h
 #define OPV__h

--- a/bootstrap/windows-88/Out.c
+++ b/bootstrap/windows-88/Out.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/Out.h
+++ b/bootstrap/windows-88/Out.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Out__h
 #define Out__h

--- a/bootstrap/windows-88/Platform.c
+++ b/bootstrap/windows-88/Platform.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/Platform.h
+++ b/bootstrap/windows-88/Platform.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Platform__h
 #define Platform__h

--- a/bootstrap/windows-88/Reals.c
+++ b/bootstrap/windows-88/Reals.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/Reals.h
+++ b/bootstrap/windows-88/Reals.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Reals__h
 #define Reals__h

--- a/bootstrap/windows-88/Strings.c
+++ b/bootstrap/windows-88/Strings.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/Strings.h
+++ b/bootstrap/windows-88/Strings.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Strings__h
 #define Strings__h

--- a/bootstrap/windows-88/Texts.c
+++ b/bootstrap/windows-88/Texts.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/Texts.h
+++ b/bootstrap/windows-88/Texts.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Texts__h
 #define Texts__h

--- a/bootstrap/windows-88/VT100.c
+++ b/bootstrap/windows-88/VT100.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/VT100.h
+++ b/bootstrap/windows-88/VT100.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef VT100__h
 #define VT100__h

--- a/bootstrap/windows-88/extTools.c
+++ b/bootstrap/windows-88/extTools.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -72,7 +72,7 @@ static void extTools_execute (CHAR *title, ADDRESS title__len, CHAR *cmd, ADDRES
 
 static void extTools_InitialiseCompilerCommand (CHAR *s, ADDRESS s__len)
 {
-	__COPY("tcc -g", s, s__len);
+	__COPY("gcc -fPIC -g", s, s__len);
 	Strings_Append((CHAR*)" -I \"", 6, (void*)s, s__len);
 	Strings_Append(OPM_ResourceDir, 1024, (void*)s, s__len);
 	Strings_Append((CHAR*)"/include\" ", 11, (void*)s, s__len);
@@ -102,7 +102,7 @@ void extTools_LinkMain (CHAR *moduleName, ADDRESS moduleName__len, BOOLEAN stati
 	Strings_Append((CHAR*)".c ", 4, (void*)cmd, 4096);
 	Strings_Append(additionalopts, additionalopts__len, (void*)cmd, 4096);
 	if (statically) {
-		Strings_Append((CHAR*)"", 1, (void*)cmd, 4096);
+		Strings_Append((CHAR*)" -static", 9, (void*)cmd, 4096);
 	}
 	Strings_Append((CHAR*)" -o ", 5, (void*)cmd, 4096);
 	Strings_Append(moduleName, moduleName__len, (void*)cmd, 4096);

--- a/bootstrap/windows-88/extTools.h
+++ b/bootstrap/windows-88/extTools.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2019/10/11]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2019/11/01]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef extTools__h
 #define extTools__h

--- a/src/compiler/OPC.Mod
+++ b/src/compiler/OPC.Mod
@@ -1215,12 +1215,15 @@ MODULE OPC;  (* copyright (c) J. Templ 12.7.95 / 3.7.96 *)
   END IntLiteral;
 
   PROCEDURE Len* (obj: OPT.Object; array: OPT.Struct; dim: SYSTEM.INT64);
+  VAR
+    d: SYSTEM.INT64;
   BEGIN
+    d := dim;
+    WHILE d > 0 DO array := array^.BaseTyp; DEC(d) END;
     IF array^.comp = OPT.DynArr THEN
       CompleteIdent(obj); OPM.WriteString(LenExt);
       IF dim # 0 THEN OPM.WriteInt(dim) END
     ELSE (* array *)
-      WHILE dim > 0 DO array := array^.BaseTyp; DEC(dim) END;
       OPM.WriteInt(array.n)
     END
   END Len;

--- a/src/compiler/OPV.Mod
+++ b/src/compiler/OPV.Mod
@@ -218,7 +218,7 @@ MODULE OPV;  (* J. Templ 16.2.95 / 3.7.96
 	  IF array^.comp = OPT.DynArr THEN
         design(n^.left, 10); OPM.WriteString("->len["); OPM.WriteInt(dim); OPM.Write("]")
 	  ELSE
-        OPM.WriteInt(array^.n); OPM.PromoteIntConstToLInt()
+        OPM.WriteInt(array^.n)
 	  END
     ELSE
       OPC.Len(n^.obj, n^.typ, dim)

--- a/src/compiler/OPV.Mod
+++ b/src/compiler/OPV.Mod
@@ -208,10 +208,18 @@ MODULE OPV;  (* J. Templ 16.2.95 / 3.7.96
   PROCEDURE^ design(n: OPT.Node; prec: INTEGER);
 
   PROCEDURE Len(n: OPT.Node; dim: SYSTEM.INT64);
+  VAR
+    d: SYSTEM.INT64; array: OPT.Struct;
   BEGIN
     WHILE (n^.class = OPT.Nindex) & (n^.typ^.comp = OPT.DynArr(*26.7.2002*)) DO INC(dim); n := n^.left END ;
     IF (n^.class = OPT.Nderef) & (n^.typ^.comp = OPT.DynArr) THEN
-      design(n^.left, 10); OPM.WriteString("->len["); OPM.WriteInt(dim); OPM.Write("]")
+	  d := dim; array := n^.typ;
+	  WHILE d > 0 DO array := array^.BaseTyp; DEC(d) END;
+	  IF array^.comp = DynArr THEN
+        design(n^.left, 10); OPM.WriteString("->len["); OPM.WriteInt(dim); OPM.Write("]")
+	  ELSE
+        OPM.WriteInt(array^.n); OPM.PromoteIntConstToLInt()
+	  END
     ELSE
       OPC.Len(n^.obj, n^.typ, dim)
     END

--- a/src/compiler/OPV.Mod
+++ b/src/compiler/OPV.Mod
@@ -215,7 +215,7 @@ MODULE OPV;  (* J. Templ 16.2.95 / 3.7.96
     IF (n^.class = OPT.Nderef) & (n^.typ^.comp = OPT.DynArr) THEN
 	  d := dim; array := n^.typ;
 	  WHILE d > 0 DO array := array^.BaseTyp; DEC(d) END;
-	  IF array^.comp = DynArr THEN
+	  IF array^.comp = OPT.DynArr THEN
         design(n^.left, 10); OPM.WriteString("->len["); OPM.WriteInt(dim); OPM.Write("]")
 	  ELSE
         OPM.WriteInt(array^.n); OPM.PromoteIntConstToLInt()


### PR DESCRIPTION
there are still warnings while compiling [Oleg's test](https://github.com/jtempl/ofront/issues/37).

```
MODULE Test;

TYPE
T1 = ARRAY 5 OF REAL;
T2 = ARRAY 5 OF T1;

PROCEDURE Do4 ( x: ARRAY OF ARRAY OF REAL );
END Do4;

PROCEDURE Do3 ( x: ARRAY OF T1 );
BEGIN
  Do4( x );
END Do3;

END Test.
```

now it compiles with the following warnings:
```
test.Mod  Compiling Test.  Main program.  694 chars.
Test.c: In function ‘Test_Do3’:
Test.c:32:11: warning: passing argument 1 of ‘Test_Do4’ from incompatible pointer type [-Wincompatible-pointer-types]
   32 |  Test_Do4(x, x__len, 5);
      |           ^
      |           |
      |           REAL (*)[5] {aka float (*)[5]}
Test.c:23:29: note: expected ‘REAL *’ {aka ‘float *’} but argument is of type ‘REAL (*)[5]’ {aka ‘float (*)[5]’}
   23 | static void Test_Do4 (REAL *x, ADDRESS x__len, ADDRESS x__len1)
```

@dcwbrown also, see my new email.