### PR TITLE
fixed ooc.C typesizes and made X11 examples compile.

### DIFF
--- a/src/library/ooc/oocCILP32.Mod
+++ b/src/library/ooc/oocCILP32.Mod
@@ -31,13 +31,13 @@ Unix they should be fairly safe.
 
 TYPE
   char*       = CHAR;                        (*  8 bits *)
-  signedchar* = SHORTINT;                    (*  8 bits *)
-  shortint*   = RECORD a,b: SYSTEM.BYTE END; (* 16 bits *)
-  int*        = LONGINT;                     (* 32 bits *)   
-  set*        = LONGINT;                     (* 32 bits *)
-  longint*    = LONGINT;                     (* 32 bits on ILP32 (64 bits is 'long long') *)
+  signedchar* = SYSTEM.INT8;                 (*  8 bits *)
+  shortint*   = SYSTEM.INT16;                (* 16 bits *)
+  int*        = SYSTEM.INT32;                (* 32 bits *)   
+  set*        = SYSTEM.INT32;                (* 32 bits *)
+  longint*    = SYSTEM.INT32;                     (* 32 bits on ILP32 (64 bits is 'long long') *)
 (*longset*    = SET;  n/a *)                 (* 64 bit SET *)
-  address*    = LONGINT;                     (* 32 bits *)
+  address*    = SYSTEM.ADDRESS;                     (* 32 bits *)
   float*      = REAL;                        (* 32 bits *)
   double*     = LONGREAL;                    (* 64 bits *)
 

--- a/src/library/ooc/oocCLLP64.Mod
+++ b/src/library/ooc/oocCLLP64.Mod
@@ -31,13 +31,13 @@ Unix they should be fairly safe.
 
 TYPE
   char*       = CHAR;                        (*  8 bits *)             
-  signedchar* = SHORTINT;                    (*  8 bits *)
-  shortint*   = RECORD a,b: SYSTEM.BYTE END; (* 16 bits *)
-  int*        = INTEGER;                     (* 32 bits *)     
-  set*        = INTEGER;                     (* 32 bits *) 
-  longint*    = INTEGER;                     (* 32 bits *)
-  longset*    = SET;                         (* 64 bits *)
-  address*    = LONGINT;                     (* 64 bits *)
+  signedchar* = SYSTEM.INT8;                 (*  8 bits *)
+  shortint*   = SYSTEM.INT16;                (* 16 bits *)
+  int*        = SYSTEM.INT32;                (* 32 bits *)     
+  set*        = SYSTEM.SET32;                (* 32 bits *) 
+  longint*    = SYSTEM.INT32;                (* 32 bits *)
+  longset*    = SYSTEM.SET64;                (* 64 bits *)
+  address*    = SYSTEM.INT64;                (* 64 bits *)
   float*      = REAL;                        (* 32 bits *)
   double*     = LONGREAL;                    (* 64 bits *)
 

--- a/src/library/ooc/oocCLP64.Mod
+++ b/src/library/ooc/oocCLP64.Mod
@@ -31,13 +31,13 @@ Unix they should be fairly safe.
 
 TYPE
   char*       = CHAR;                        (*  8 bits *)             
-  signedchar* = SHORTINT;                    (*  8 bits *)
-  shortint*   = RECORD a,b: SYSTEM.BYTE END; (* 16 bits *)
-  int*        = INTEGER;                     (* 32 bits *)     
-  set*        = INTEGER;                     (* 32 bits *) 
-  longint*    = LONGINT;                     (* 64 bits *)
-  longset*    = SET;                         (* 64 bits *)
-  address*    = LONGINT;                     (* 64 bits *)
+  signedchar* = SYSTEM.INT8;                 (*  8 bits *)
+  shortint*   = SYSTEM.INT16;                (* 16 bits *)
+  int*        = SYSTEM.INT32;                (* 32 bits *)     
+  set*        = SYSTEM.INT32;                (* 32 bits *) 
+  longint*    = SYSTEM.INT64;                (* 64 bits *)
+  longset*    = SYSTEM.SET64;                (* 64 bits *)
+  address*    = SYSTEM.ADDRESS;              (* 64 bits *)
   float*      = REAL;                        (* 32 bits *)
   double*     = LONGREAL;                    (* 64 bits *)
 

--- a/src/test/x11/0/makefile
+++ b/src/test/x11/0/makefile
@@ -1,12 +1,12 @@
 #for old systems like RHEL4 use
 #CFLAGS=-L/usr/X11R6/lib -lX11
+MODX11="../../../library/oocX11"
 CFLAGS=-lX11
 export CFLAGS
-MOD = MODULES="../../../lib/oocX11"
 VOC = $(MOD) /opt/voc/bin/voc
 
 all:
-	$(VOC) -s oocX11.Mod oocXutil.Mod oocXYplane.Mod test.Mod -m
+	$(VOC) -s $(MODX11)/oocX11.Mod $(MODX11)/oocXutil.Mod $(MODX11)/oocXYplane.Mod test.Mod -m
 	#$(VOC) -Cm test.Mod
 	#gcc -o test  test.o -fPIC -g -I /opt/voc-1.0/src/lib/system/gcc/x86_64 -I /opt/voc-1.0/lib/voc/obj -lVishapOberon -L. -L/opt/voc-1.0/lib -lX11
 

--- a/src/test/x11/IFS/makefile
+++ b/src/test/x11/IFS/makefile
@@ -1,11 +1,10 @@
 CFLAGS=-lX11
 export CFLAGS
-
-MOD = MODULES="../../../lib/oocX11"
+MODX11="../../../library/oocX11"
 VOC = $(MOD) /opt/voc/bin/voc
 
 all:
-	$(VOC) -s oocX11.Mod oocXutil.Mod oocXYplane.Mod IFS.Mod IFStest.Mod -m
+	$(VOC) -s $(MODX11)/oocX11.Mod $(MODX11)/oocXutil.Mod $(MODX11)/oocXYplane.Mod IFS.Mod IFStest.Mod -m
 	#$(VOC) -Cm test.Mod
 	#gcc -o test  test.o -fPIC -g -I /opt/voc-1.0/src/lib/system/gcc/x86_64 -I /opt/voc-1.0/lib/voc/obj -lVishapOberon -L. -L/opt/voc-1.0/lib -lX11
 

--- a/src/test/x11/mines/makefile
+++ b/src/test/x11/mines/makefile
@@ -3,11 +3,12 @@
 CFLAGS=-lX11
 export CFLAGS
 
-MOD = MODULES="../../../lib/oocX11"
+MODX11="../../../library/oocX11"
+
 VOC = $(MOD) /opt/voc/bin/voc
 
 all:
-	$(VOC) -s oocX11.Mod oocXutil.Mod oocXYplane.Mod compatIn.Mod Linie.Mod Minesweeper.Mod -m
+	$(VOC) -s $(MODX11)/oocX11.Mod $(MODX11)/oocXutil.Mod $(MODX11)/oocXYplane.Mod compatIn.Mod Linie.Mod Minesweeper.Mod -m
 	#$(VOC) -Cm test.Mod
 	#gcc -o test  test.o -fPIC -g -I /opt/voc-1.0/src/lib/system/gcc/x86_64 -I /opt/voc-1.0/lib/voc/obj -lVishapOberon -L. -L/opt/voc-1.0/lib -lX11
 

--- a/src/test/x11/pacman/makefile
+++ b/src/test/x11/pacman/makefile
@@ -3,11 +3,12 @@
 CFLAGS=-lX11
 export CFLAGS
 
-MOD = MODULES="../../../lib/oocX11"
+MODX11="../../../library/oocX11"
+
 VOC = $(MOD) /opt/voc/bin/voc
 
 all:
-	$(VOC) -s oocX11.Mod oocXutil.Mod oocXYplane.Mod Grafik.Mod PacMan.Mod -m
+	$(VOC) -s $(MODX11)/oocX11.Mod $(MODX11)/oocXutil.Mod $(MODX11)/oocXYplane.Mod Grafik.Mod PacMan.Mod -m
 	#$(VOC) -Cm test.Mod
 	#gcc -o test  test.o -fPIC -g -I /opt/voc-1.0/src/lib/system/gcc/x86_64 -I /opt/voc-1.0/lib/voc/obj -lVishapOberon -L. -L/opt/voc-1.0/lib -lX11
 

--- a/src/test/x11/tetris/Tetris.Mod
+++ b/src/test/x11/tetris/Tetris.Mod
@@ -5,7 +5,7 @@ MODULE Tetris;
 (* Neuerungen: Spielparameter sind ueber Konstantendeklariert, Zweispielermodus 
   bricht bei Limit-Linien ab, Pause-Funktion wurde eingefuehrt *)
 
-IMPORT X:=oocXYplane, L:=Linie, In := compatIn, Out := Console, RN:=ethRandomNumbers, Ziffer, Oberon := Kernel;
+IMPORT X:=oocXYplane, L:=Linie, In := compatIn, Out := Console, RN:=ethRandomNumbers, Ziffer, Oberon;
 
 CONST 
 

--- a/src/test/x11/tetris/makefile
+++ b/src/test/x11/tetris/makefile
@@ -3,11 +3,12 @@
 CFLAGS=-lX11
 export CFLAGS
 
-MOD = MODULES="../../../lib/oocX11"
+MODX11="../../../library/oocX11"
+
 VOC = $(MOD) /opt/voc/bin/voc
 
 all:
-	$(VOC) -s oocX11.Mod oocXutil.Mod oocXYplane.Mod compatIn.Mod Linie.Mod Ziffer.Mod Tetris.Mod -m
+	$(VOC) -s $(MODX11)/oocX11.Mod $(MODX11)/oocXutil.Mod $(MODX11)/oocXYplane.Mod compatIn.Mod Linie.Mod Ziffer.Mod Tetris.Mod -m
 	#$(VOC) -Cm test.Mod
 	#gcc -o test  test.o -fPIC -g -I /opt/voc-1.0/src/lib/system/gcc/x86_64 -I /opt/voc-1.0/lib/voc/obj -lVishapOberon -L. -L/opt/voc-1.0/lib -lX11
 

--- a/src/test/x11/tron/makefile
+++ b/src/test/x11/tron/makefile
@@ -3,11 +3,11 @@
 CFLAGS=-lX11
 export CFLAGS
 
-MOD = MODULES="../../../lib/oocX11"
+MODX11="../../../library/oocX11"
 VOC = $(MOD) /opt/voc/bin/voc
 
 all:
-	$(VOC) -s oocX11.Mod oocXutil.Mod oocXYplane.Mod compatIn.Mod Tron.Mod -m
+	$(VOC) -s $(MODX11)/oocX11.Mod $(MODX11)/oocXutil.Mod $(MODX11)/oocXYplane.Mod compatIn.Mod Tron.Mod -m
 	#$(VOC) -Cm test.Mod
 	#gcc -o test  test.o -fPIC -g -I /opt/voc-1.0/src/lib/system/gcc/x86_64 -I /opt/voc-1.0/lib/voc/obj -lVishapOberon -L. -L/opt/voc-1.0/lib -lX11
 

--- a/src/test/x11/vier/makefile
+++ b/src/test/x11/vier/makefile
@@ -3,11 +3,12 @@
 CFLAGS=-lX11
 export CFLAGS
 
-MOD = MODULES="../../../lib/oocX11"
+MODX11="../../../library/oocX11"
+
 VOC = $(MOD) /opt/voc/bin/voc
 
 all:
-	$(VOC) -s oocX11.Mod oocXutil.Mod oocXYplane.Mod compatIn.Mod Ausgabe.Mod Vier.Mod -m
+	$(VOC) -s $(MODX11)/oocX11.Mod $(MODX11)/oocXutil.Mod $(MODX11)/oocXYplane.Mod compatIn.Mod Ausgabe.Mod Vier.Mod -m
 	#$(VOC) -Cm test.Mod
 	#gcc -o test  test.o -fPIC -g -I /opt/voc-1.0/src/lib/system/gcc/x86_64 -I /opt/voc-1.0/lib/voc/obj -lVishapOberon -L. -L/opt/voc-1.0/lib -lX11
 


### PR DESCRIPTION
oocC.Mod interface to C sizes was wrong and outdated.
wrong, because some of the values were wrong (integer for sure), and outdated, because it could've use voc new type model where we have INT16, INT8 etc.

I found this problem by troubleshooting oocXYplane, and X11 test programs.

Now they compile.

P. S. in the future, when we'll have a useful package manager, I believe x11 tests and wrappers have to be moved out from voc source tree and reside in a separate repository.