### PR TITLE
now "NIL access" error in Modules.Mod indeed works.

### DIFF
--- a/bootstrap/SYSTEM.h
+++ b/bootstrap/SYSTEM.h
@@ -265,7 +265,10 @@ extern void       Heap_INCREF();
 extern void Modules_Init(INT32 argc, ADDRESS argv);
 extern void Heap_FINALL();
 
-#define __INIT(argc, argv)    static void *m; Modules_Init(argc, (ADDRESS)&argv);
+extern void setupAutomaticSegfaultHandler();
+
+#define __INIT(argc, argv)    static void *m; setupAutomaticSegfaultHandler(); Modules_Init(argc, (ADDRESS)&argv);
+
 #define __REGMAIN(name, enum) m = Heap_REGMOD((CHAR*)name,enum)
 #define __FINI                Heap_FINALL(); return 0
 

--- a/bootstrap/unix-44/Compiler.c
+++ b/bootstrap/unix-44/Compiler.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/Configuration.c
+++ b/bootstrap/unix-44/Configuration.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -19,6 +19,6 @@ export void *Configuration__init(void)
 	__DEFMOD;
 	__REGMOD("Configuration", 0);
 /* BEGIN */
-	__MOVE("2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
+	__MOVE("2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
 	__ENDMOD;
 }

--- a/bootstrap/unix-44/Configuration.h
+++ b/bootstrap/unix-44/Configuration.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Configuration__h
 #define Configuration__h

--- a/bootstrap/unix-44/Files.c
+++ b/bootstrap/unix-44/Files.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/Files.h
+++ b/bootstrap/unix-44/Files.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Files__h
 #define Files__h

--- a/bootstrap/unix-44/Heap.c
+++ b/bootstrap/unix-44/Heap.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/Heap.h
+++ b/bootstrap/unix-44/Heap.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #ifndef Heap__h
 #define Heap__h

--- a/bootstrap/unix-44/Modules.c
+++ b/bootstrap/unix-44/Modules.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/Modules.h
+++ b/bootstrap/unix-44/Modules.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Modules__h
 #define Modules__h

--- a/bootstrap/unix-44/OPB.c
+++ b/bootstrap/unix-44/OPB.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/OPB.h
+++ b/bootstrap/unix-44/OPB.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPB__h
 #define OPB__h

--- a/bootstrap/unix-44/OPC.c
+++ b/bootstrap/unix-44/OPC.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/OPC.h
+++ b/bootstrap/unix-44/OPC.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPC__h
 #define OPC__h

--- a/bootstrap/unix-44/OPM.c
+++ b/bootstrap/unix-44/OPM.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/OPM.h
+++ b/bootstrap/unix-44/OPM.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPM__h
 #define OPM__h

--- a/bootstrap/unix-44/OPP.c
+++ b/bootstrap/unix-44/OPP.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/OPP.h
+++ b/bootstrap/unix-44/OPP.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPP__h
 #define OPP__h

--- a/bootstrap/unix-44/OPS.c
+++ b/bootstrap/unix-44/OPS.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/OPS.h
+++ b/bootstrap/unix-44/OPS.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPS__h
 #define OPS__h

--- a/bootstrap/unix-44/OPT.c
+++ b/bootstrap/unix-44/OPT.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/OPT.h
+++ b/bootstrap/unix-44/OPT.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPT__h
 #define OPT__h

--- a/bootstrap/unix-44/OPV.c
+++ b/bootstrap/unix-44/OPV.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/OPV.h
+++ b/bootstrap/unix-44/OPV.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPV__h
 #define OPV__h

--- a/bootstrap/unix-44/Out.c
+++ b/bootstrap/unix-44/Out.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/Out.h
+++ b/bootstrap/unix-44/Out.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Out__h
 #define Out__h

--- a/bootstrap/unix-44/Platform.c
+++ b/bootstrap/unix-44/Platform.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/Platform.h
+++ b/bootstrap/unix-44/Platform.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Platform__h
 #define Platform__h

--- a/bootstrap/unix-44/Reals.c
+++ b/bootstrap/unix-44/Reals.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/Reals.h
+++ b/bootstrap/unix-44/Reals.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Reals__h
 #define Reals__h

--- a/bootstrap/unix-44/Strings.c
+++ b/bootstrap/unix-44/Strings.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/Strings.h
+++ b/bootstrap/unix-44/Strings.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Strings__h
 #define Strings__h

--- a/bootstrap/unix-44/Texts.c
+++ b/bootstrap/unix-44/Texts.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/Texts.h
+++ b/bootstrap/unix-44/Texts.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Texts__h
 #define Texts__h

--- a/bootstrap/unix-44/VT100.c
+++ b/bootstrap/unix-44/VT100.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/VT100.h
+++ b/bootstrap/unix-44/VT100.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef VT100__h
 #define VT100__h

--- a/bootstrap/unix-44/extTools.c
+++ b/bootstrap/unix-44/extTools.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-44/extTools.h
+++ b/bootstrap/unix-44/extTools.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef extTools__h
 #define extTools__h

--- a/bootstrap/unix-48/Compiler.c
+++ b/bootstrap/unix-48/Compiler.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/Configuration.c
+++ b/bootstrap/unix-48/Configuration.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -19,6 +19,6 @@ export void *Configuration__init(void)
 	__DEFMOD;
 	__REGMOD("Configuration", 0);
 /* BEGIN */
-	__MOVE("2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
+	__MOVE("2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
 	__ENDMOD;
 }

--- a/bootstrap/unix-48/Configuration.h
+++ b/bootstrap/unix-48/Configuration.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Configuration__h
 #define Configuration__h

--- a/bootstrap/unix-48/Files.c
+++ b/bootstrap/unix-48/Files.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/Files.h
+++ b/bootstrap/unix-48/Files.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Files__h
 #define Files__h

--- a/bootstrap/unix-48/Heap.c
+++ b/bootstrap/unix-48/Heap.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/Heap.h
+++ b/bootstrap/unix-48/Heap.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #ifndef Heap__h
 #define Heap__h

--- a/bootstrap/unix-48/Modules.c
+++ b/bootstrap/unix-48/Modules.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/Modules.h
+++ b/bootstrap/unix-48/Modules.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Modules__h
 #define Modules__h

--- a/bootstrap/unix-48/OPB.c
+++ b/bootstrap/unix-48/OPB.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/OPB.h
+++ b/bootstrap/unix-48/OPB.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPB__h
 #define OPB__h

--- a/bootstrap/unix-48/OPC.c
+++ b/bootstrap/unix-48/OPC.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/OPC.h
+++ b/bootstrap/unix-48/OPC.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPC__h
 #define OPC__h

--- a/bootstrap/unix-48/OPM.c
+++ b/bootstrap/unix-48/OPM.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/OPM.h
+++ b/bootstrap/unix-48/OPM.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPM__h
 #define OPM__h

--- a/bootstrap/unix-48/OPP.c
+++ b/bootstrap/unix-48/OPP.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/OPP.h
+++ b/bootstrap/unix-48/OPP.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPP__h
 #define OPP__h

--- a/bootstrap/unix-48/OPS.c
+++ b/bootstrap/unix-48/OPS.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/OPS.h
+++ b/bootstrap/unix-48/OPS.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPS__h
 #define OPS__h

--- a/bootstrap/unix-48/OPT.c
+++ b/bootstrap/unix-48/OPT.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/OPT.h
+++ b/bootstrap/unix-48/OPT.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPT__h
 #define OPT__h

--- a/bootstrap/unix-48/OPV.c
+++ b/bootstrap/unix-48/OPV.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/OPV.h
+++ b/bootstrap/unix-48/OPV.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPV__h
 #define OPV__h

--- a/bootstrap/unix-48/Out.c
+++ b/bootstrap/unix-48/Out.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/Out.h
+++ b/bootstrap/unix-48/Out.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Out__h
 #define Out__h

--- a/bootstrap/unix-48/Platform.c
+++ b/bootstrap/unix-48/Platform.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/Platform.h
+++ b/bootstrap/unix-48/Platform.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Platform__h
 #define Platform__h

--- a/bootstrap/unix-48/Reals.c
+++ b/bootstrap/unix-48/Reals.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/Reals.h
+++ b/bootstrap/unix-48/Reals.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Reals__h
 #define Reals__h

--- a/bootstrap/unix-48/Strings.c
+++ b/bootstrap/unix-48/Strings.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/Strings.h
+++ b/bootstrap/unix-48/Strings.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Strings__h
 #define Strings__h

--- a/bootstrap/unix-48/Texts.c
+++ b/bootstrap/unix-48/Texts.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/Texts.h
+++ b/bootstrap/unix-48/Texts.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Texts__h
 #define Texts__h

--- a/bootstrap/unix-48/VT100.c
+++ b/bootstrap/unix-48/VT100.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/VT100.h
+++ b/bootstrap/unix-48/VT100.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef VT100__h
 #define VT100__h

--- a/bootstrap/unix-48/extTools.c
+++ b/bootstrap/unix-48/extTools.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-48/extTools.h
+++ b/bootstrap/unix-48/extTools.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef extTools__h
 #define extTools__h

--- a/bootstrap/unix-88/Compiler.c
+++ b/bootstrap/unix-88/Compiler.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/Configuration.c
+++ b/bootstrap/unix-88/Configuration.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -19,6 +19,6 @@ export void *Configuration__init(void)
 	__DEFMOD;
 	__REGMOD("Configuration", 0);
 /* BEGIN */
-	__MOVE("2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
+	__MOVE("2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
 	__ENDMOD;
 }

--- a/bootstrap/unix-88/Configuration.h
+++ b/bootstrap/unix-88/Configuration.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Configuration__h
 #define Configuration__h

--- a/bootstrap/unix-88/Files.c
+++ b/bootstrap/unix-88/Files.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/Files.h
+++ b/bootstrap/unix-88/Files.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Files__h
 #define Files__h

--- a/bootstrap/unix-88/Heap.c
+++ b/bootstrap/unix-88/Heap.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/Heap.h
+++ b/bootstrap/unix-88/Heap.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #ifndef Heap__h
 #define Heap__h

--- a/bootstrap/unix-88/Modules.c
+++ b/bootstrap/unix-88/Modules.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/Modules.h
+++ b/bootstrap/unix-88/Modules.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Modules__h
 #define Modules__h

--- a/bootstrap/unix-88/OPB.c
+++ b/bootstrap/unix-88/OPB.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/OPB.h
+++ b/bootstrap/unix-88/OPB.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPB__h
 #define OPB__h

--- a/bootstrap/unix-88/OPC.c
+++ b/bootstrap/unix-88/OPC.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/OPC.h
+++ b/bootstrap/unix-88/OPC.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPC__h
 #define OPC__h

--- a/bootstrap/unix-88/OPM.c
+++ b/bootstrap/unix-88/OPM.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/OPM.h
+++ b/bootstrap/unix-88/OPM.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPM__h
 #define OPM__h

--- a/bootstrap/unix-88/OPP.c
+++ b/bootstrap/unix-88/OPP.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/OPP.h
+++ b/bootstrap/unix-88/OPP.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPP__h
 #define OPP__h

--- a/bootstrap/unix-88/OPS.c
+++ b/bootstrap/unix-88/OPS.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/OPS.h
+++ b/bootstrap/unix-88/OPS.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPS__h
 #define OPS__h

--- a/bootstrap/unix-88/OPT.c
+++ b/bootstrap/unix-88/OPT.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/OPT.h
+++ b/bootstrap/unix-88/OPT.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPT__h
 #define OPT__h

--- a/bootstrap/unix-88/OPV.c
+++ b/bootstrap/unix-88/OPV.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/OPV.h
+++ b/bootstrap/unix-88/OPV.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPV__h
 #define OPV__h

--- a/bootstrap/unix-88/Out.c
+++ b/bootstrap/unix-88/Out.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/Out.h
+++ b/bootstrap/unix-88/Out.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Out__h
 #define Out__h

--- a/bootstrap/unix-88/Platform.c
+++ b/bootstrap/unix-88/Platform.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/Platform.h
+++ b/bootstrap/unix-88/Platform.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Platform__h
 #define Platform__h

--- a/bootstrap/unix-88/Reals.c
+++ b/bootstrap/unix-88/Reals.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/Reals.h
+++ b/bootstrap/unix-88/Reals.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Reals__h
 #define Reals__h

--- a/bootstrap/unix-88/Strings.c
+++ b/bootstrap/unix-88/Strings.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/Strings.h
+++ b/bootstrap/unix-88/Strings.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Strings__h
 #define Strings__h

--- a/bootstrap/unix-88/Texts.c
+++ b/bootstrap/unix-88/Texts.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/Texts.h
+++ b/bootstrap/unix-88/Texts.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Texts__h
 #define Texts__h

--- a/bootstrap/unix-88/VT100.c
+++ b/bootstrap/unix-88/VT100.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/VT100.h
+++ b/bootstrap/unix-88/VT100.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef VT100__h
 #define VT100__h

--- a/bootstrap/unix-88/extTools.c
+++ b/bootstrap/unix-88/extTools.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/unix-88/extTools.h
+++ b/bootstrap/unix-88/extTools.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef extTools__h
 #define extTools__h

--- a/bootstrap/windows-48/Compiler.c
+++ b/bootstrap/windows-48/Compiler.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/Configuration.c
+++ b/bootstrap/windows-48/Configuration.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -19,6 +19,6 @@ export void *Configuration__init(void)
 	__DEFMOD;
 	__REGMOD("Configuration", 0);
 /* BEGIN */
-	__MOVE("2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
+	__MOVE("2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
 	__ENDMOD;
 }

--- a/bootstrap/windows-48/Configuration.h
+++ b/bootstrap/windows-48/Configuration.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Configuration__h
 #define Configuration__h

--- a/bootstrap/windows-48/Files.c
+++ b/bootstrap/windows-48/Files.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/Files.h
+++ b/bootstrap/windows-48/Files.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Files__h
 #define Files__h

--- a/bootstrap/windows-48/Heap.c
+++ b/bootstrap/windows-48/Heap.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/Heap.h
+++ b/bootstrap/windows-48/Heap.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #ifndef Heap__h
 #define Heap__h

--- a/bootstrap/windows-48/Modules.c
+++ b/bootstrap/windows-48/Modules.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/Modules.h
+++ b/bootstrap/windows-48/Modules.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Modules__h
 #define Modules__h

--- a/bootstrap/windows-48/OPB.c
+++ b/bootstrap/windows-48/OPB.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/OPB.h
+++ b/bootstrap/windows-48/OPB.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPB__h
 #define OPB__h

--- a/bootstrap/windows-48/OPC.c
+++ b/bootstrap/windows-48/OPC.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/OPC.h
+++ b/bootstrap/windows-48/OPC.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPC__h
 #define OPC__h

--- a/bootstrap/windows-48/OPM.c
+++ b/bootstrap/windows-48/OPM.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/OPM.h
+++ b/bootstrap/windows-48/OPM.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPM__h
 #define OPM__h

--- a/bootstrap/windows-48/OPP.c
+++ b/bootstrap/windows-48/OPP.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/OPP.h
+++ b/bootstrap/windows-48/OPP.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPP__h
 #define OPP__h

--- a/bootstrap/windows-48/OPS.c
+++ b/bootstrap/windows-48/OPS.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/OPS.h
+++ b/bootstrap/windows-48/OPS.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPS__h
 #define OPS__h

--- a/bootstrap/windows-48/OPT.c
+++ b/bootstrap/windows-48/OPT.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/OPT.h
+++ b/bootstrap/windows-48/OPT.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPT__h
 #define OPT__h

--- a/bootstrap/windows-48/OPV.c
+++ b/bootstrap/windows-48/OPV.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/OPV.h
+++ b/bootstrap/windows-48/OPV.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPV__h
 #define OPV__h

--- a/bootstrap/windows-48/Out.c
+++ b/bootstrap/windows-48/Out.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/Out.h
+++ b/bootstrap/windows-48/Out.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Out__h
 #define Out__h

--- a/bootstrap/windows-48/Platform.c
+++ b/bootstrap/windows-48/Platform.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/Platform.h
+++ b/bootstrap/windows-48/Platform.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Platform__h
 #define Platform__h

--- a/bootstrap/windows-48/Reals.c
+++ b/bootstrap/windows-48/Reals.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/Reals.h
+++ b/bootstrap/windows-48/Reals.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Reals__h
 #define Reals__h

--- a/bootstrap/windows-48/Strings.c
+++ b/bootstrap/windows-48/Strings.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/Strings.h
+++ b/bootstrap/windows-48/Strings.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Strings__h
 #define Strings__h

--- a/bootstrap/windows-48/Texts.c
+++ b/bootstrap/windows-48/Texts.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/Texts.h
+++ b/bootstrap/windows-48/Texts.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Texts__h
 #define Texts__h

--- a/bootstrap/windows-48/VT100.c
+++ b/bootstrap/windows-48/VT100.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/VT100.h
+++ b/bootstrap/windows-48/VT100.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef VT100__h
 #define VT100__h

--- a/bootstrap/windows-48/extTools.c
+++ b/bootstrap/windows-48/extTools.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-48/extTools.h
+++ b/bootstrap/windows-48/extTools.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef extTools__h
 #define extTools__h

--- a/bootstrap/windows-88/Compiler.c
+++ b/bootstrap/windows-88/Compiler.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspamS */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/Configuration.c
+++ b/bootstrap/windows-88/Configuration.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16
@@ -19,6 +19,6 @@ export void *Configuration__init(void)
 	__DEFMOD;
 	__REGMOD("Configuration", 0);
 /* BEGIN */
-	__MOVE("2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
+	__MOVE("2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8.", Configuration_versionLong, 76);
 	__ENDMOD;
 }

--- a/bootstrap/windows-88/Configuration.h
+++ b/bootstrap/windows-88/Configuration.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Configuration__h
 #define Configuration__h

--- a/bootstrap/windows-88/Files.c
+++ b/bootstrap/windows-88/Files.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/Files.h
+++ b/bootstrap/windows-88/Files.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Files__h
 #define Files__h

--- a/bootstrap/windows-88/Heap.c
+++ b/bootstrap/windows-88/Heap.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/Heap.h
+++ b/bootstrap/windows-88/Heap.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. rtsSF */
 
 #ifndef Heap__h
 #define Heap__h

--- a/bootstrap/windows-88/Modules.c
+++ b/bootstrap/windows-88/Modules.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/Modules.h
+++ b/bootstrap/windows-88/Modules.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Modules__h
 #define Modules__h

--- a/bootstrap/windows-88/OPB.c
+++ b/bootstrap/windows-88/OPB.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/OPB.h
+++ b/bootstrap/windows-88/OPB.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPB__h
 #define OPB__h

--- a/bootstrap/windows-88/OPC.c
+++ b/bootstrap/windows-88/OPC.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/OPC.h
+++ b/bootstrap/windows-88/OPC.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPC__h
 #define OPC__h

--- a/bootstrap/windows-88/OPM.c
+++ b/bootstrap/windows-88/OPM.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/OPM.h
+++ b/bootstrap/windows-88/OPM.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPM__h
 #define OPM__h

--- a/bootstrap/windows-88/OPP.c
+++ b/bootstrap/windows-88/OPP.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/OPP.h
+++ b/bootstrap/windows-88/OPP.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPP__h
 #define OPP__h

--- a/bootstrap/windows-88/OPS.c
+++ b/bootstrap/windows-88/OPS.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/OPS.h
+++ b/bootstrap/windows-88/OPS.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPS__h
 #define OPS__h

--- a/bootstrap/windows-88/OPT.c
+++ b/bootstrap/windows-88/OPT.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/OPT.h
+++ b/bootstrap/windows-88/OPT.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPT__h
 #define OPT__h

--- a/bootstrap/windows-88/OPV.c
+++ b/bootstrap/windows-88/OPV.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/OPV.h
+++ b/bootstrap/windows-88/OPV.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef OPV__h
 #define OPV__h

--- a/bootstrap/windows-88/Out.c
+++ b/bootstrap/windows-88/Out.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/Out.h
+++ b/bootstrap/windows-88/Out.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Out__h
 #define Out__h

--- a/bootstrap/windows-88/Platform.c
+++ b/bootstrap/windows-88/Platform.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/Platform.h
+++ b/bootstrap/windows-88/Platform.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Platform__h
 #define Platform__h

--- a/bootstrap/windows-88/Reals.c
+++ b/bootstrap/windows-88/Reals.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/Reals.h
+++ b/bootstrap/windows-88/Reals.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Reals__h
 #define Reals__h

--- a/bootstrap/windows-88/Strings.c
+++ b/bootstrap/windows-88/Strings.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/Strings.h
+++ b/bootstrap/windows-88/Strings.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Strings__h
 #define Strings__h

--- a/bootstrap/windows-88/Texts.c
+++ b/bootstrap/windows-88/Texts.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/Texts.h
+++ b/bootstrap/windows-88/Texts.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef Texts__h
 #define Texts__h

--- a/bootstrap/windows-88/VT100.c
+++ b/bootstrap/windows-88/VT100.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/VT100.h
+++ b/bootstrap/windows-88/VT100.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef VT100__h
 #define VT100__h

--- a/bootstrap/windows-88/extTools.c
+++ b/bootstrap/windows-88/extTools.c
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #define SHORTINT INT8
 #define INTEGER  INT16

--- a/bootstrap/windows-88/extTools.h
+++ b/bootstrap/windows-88/extTools.h
@@ -1,4 +1,4 @@
-/* voc 2.1.0 [2024/04/12]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
+/* voc 2.1.0 [2024/04/13]. Bootstrapping compiler for address size 8, alignment 8. xrtspaSF */
 
 #ifndef extTools__h
 #define extTools__h

--- a/src/runtime/SYSTEM.h
+++ b/src/runtime/SYSTEM.h
@@ -265,7 +265,10 @@ extern void       Heap_INCREF();
 extern void Modules_Init(INT32 argc, ADDRESS argv);
 extern void Heap_FINALL();
 
-#define __INIT(argc, argv)    static void *m; Modules_Init(argc, (ADDRESS)&argv);
+extern void setupAutomaticSegfaultHandler();
+
+#define __INIT(argc, argv)    static void *m; setupAutomaticSegfaultHandler(); Modules_Init(argc, (ADDRESS)&argv);
+
 #define __REGMAIN(name, enum) m = Heap_REGMOD((CHAR*)name,enum)
 #define __FINI                Heap_FINALL(); return 0
 


### PR DESCRIPTION
![nil](https://github.com/vishaps/voc/assets/11881650/0480fd67-e93b-411e-a270-9531598025ed)

tested on linux/x86_64, linux/aarch64 and freebsd 15/x86_64.