### PR TITLE
Fixes build problems on gcc 15

### DIFF
--- a/src/tools/make/configure.c
+++ b/src/tools/make/configure.c
@@ -126,7 +126,7 @@ void determineOS() {
 
 #define optimize "" // " -O1"
 // FIXME ignoring warning floods that possibly are problems
-#define ignore_gcc_warning_flood " -Wno-stringop-overflow"
+#define ignore_gcc_warning_flood " -Wno-stringop-overflow -std=gnu11"
 #define ignore_clang_warning_flood " -Wno-deprecated-non-prototype"
 
 void determineCCompiler() {


### PR DESCRIPTION
GCC 15 changes the C language standard to gnu23, and VOC compiles just fine on gnu11.

Tested against GCC 15 and GCC 14.